### PR TITLE
Fix filename generation ops_print_dat_to_txtfile

### DIFF
--- a/ops/c/src/mpi/ops_mpi_core.cpp
+++ b/ops/c/src/mpi/ops_mpi_core.cpp
@@ -317,12 +317,12 @@ bool ops_checkpointing_filename(const char *file_name, std::string &filename_out
 {
   filename_out = file_name;
   filename_out += ".";
-  filename_out += ops_my_global_rank;
+  filename_out += std::to_string(ops_my_global_rank);
 
   filename_out2 = file_name;
   filename_out2 += ".";
-  filename_out2 += 
-       (ops_my_global_rank + OPS_instance::getOPSInstance()->OPS_ranks_per_node) % ops_comm_global_size;
+  filename_out2 += std::to_string(
+       (ops_my_global_rank + OPS_instance::getOPSInstance()->OPS_ranks_per_node) % ops_comm_global_size);
   filename_out2 += ".dup";
 
   return (OPS_instance::getOPSInstance()->OPS_enable_checkpointing > 1);

--- a/ops/c/src/mpi/ops_mpi_decl.cpp
+++ b/ops/c/src/mpi/ops_mpi_decl.cpp
@@ -167,9 +167,7 @@ ops_halo ops_decl_halo(ops_dat from, ops_dat to, int *iter_size, int *from_base,
 
 void ops_print_dat_to_txtfile(ops_dat dat, const char *file_name) {
   if (OPS_sub_block_list[dat->block->index]->owned == 1) {
-    char buf[50];
-    sprintf(buf,"%s.%d",file_name,ops_my_global_rank);
-    ops_print_dat_to_txtfile_core(dat, buf);
+    ops_print_dat_to_txtfile_core(dat, file_name);
   }
 }
 


### PR DESCRIPTION
ops_print_dat_to_txtfile would generate incorrect filename suffixes
for MPI code. Fixes #140 