### PR TITLE
Fix pointers in OPS_consts arrays in CUDA codegen

### DIFF
--- a/ops_translator/c/ops_gen_mpi_cuda.py
+++ b/ops_translator/c/ops_gen_mpi_cuda.py
@@ -689,6 +689,7 @@ def ops_gen_mpi_cuda(master, date, consts, kernels, soa_set):
 
     if GBL_READ == True and GBL_READ_MDIM == True:
       code('reallocConstArrays(block->instance,consts_bytes);')
+      code('consts_bytes = 0;')
     if GBL_INC == True or GBL_MIN == True or GBL_MAX == True or GBL_WRITE == True:
       code('reallocReductArrays(block->instance,reduct_bytes);')
       code('reduct_bytes = 0;')
@@ -713,11 +714,10 @@ def ops_gen_mpi_cuda(master, date, consts, kernels, soa_set):
     for n in range (0, nargs):
       if arg_typ[n] == 'ops_arg_gbl':
         if accs[n] == OPS_READ and (not dims[n].isdigit() or int(dims[n])>1):
-          code('consts_bytes = 0;')
           code('arg'+str(n)+'.data = block->instance->OPS_consts_h + consts_bytes;')
           code('arg'+str(n)+'.data_d = block->instance->OPS_consts_d + consts_bytes;')
           code('for (int d=0; d<'+str(dims[n])+'; d++) (('+typs[n]+' *)arg'+str(n)+'.data)[d] = arg'+str(n)+'h[d];')
-          code('consts_bytes += ROUND_UP('+str(dims[n])+'*sizeof(int));')
+          code('consts_bytes += ROUND_UP('+str(dims[n])+'*sizeof('+typs[n]+'));')
     if GBL_READ == True and GBL_READ_MDIM == True:
       code('mvConstArraysToDevice(block->instance,consts_bytes);')
 


### PR DESCRIPTION
Fix global read arguments with multiple values:

  * For each ops_arg_gbl, the pointer was set to the beginning of the
    consts arrays. (misplaced line to zero out consts_bytes variable)
  * For each ops_arg_gbl, the code generator used sizeof(int) instead of
    the correct type size.