### PR TITLE
Fix/decl const cpp api

### DIFF
--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -216,7 +216,7 @@ class OPS_instance {
       if (type_error(data, type)) {
         OPSException ex(OPS_HDF5_ERROR);
         ex << "Error: incorrect type specified for constant " << name
-           << " in ops_decl_const";
+           << " in OPS_instance::decl_const";
         throw ex;
       }
       ops_decl_const_char(this, name, dim, type, data);

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -213,6 +213,12 @@ class OPS_instance {
  */
     template <class T>
     void decl_const(char const *name, int dim, char const *type, T *data) {
+      if (type_error(data, type)) {
+        OPSException ex(OPS_HDF5_ERROR);
+        ex << "Error: incorrect type specified for constant " << name
+           << " in ops_decl_const";
+        throw ex;
+      }
       ops_decl_const_char(this, name, dim, type, data);
     }
 

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -216,7 +216,7 @@ class OPS_instance {
            << " in OPS_instance::decl_const";
         throw ex;
       }
-      ops_decl_const_char(this, name, dim, type, data);
+      ops_decl_const_char(this, dim, type, sizeof(T), (char *)data, name);
     }
 
 /**

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -213,7 +213,7 @@ class OPS_instance {
  */
     template <class T>
     void decl_const(char const *name, int dim, char const *type, T *data) {
-      _ops_decl_const(this, name, dim, type, data);
+      ops_decl_const_char(this, name, dim, type, data);
     }
 
 /**

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -39,9 +39,6 @@
 #ifndef __OPS_INSTANCE_H
 #define __OPS_INSTANCE_H
 
-#include <ops_lib_core.h>
-#include <ops_checkpointing.h>
-
 #if defined(_OPENMP)
   #include <omp.h>
 #endif

--- a/ops/c/include/ops_internal1.h
+++ b/ops/c/include/ops_internal1.h
@@ -95,7 +95,7 @@ ops_arg ops_arg_gbl_char(char *data, int dim, int size, ops_access acc);
 OPS_FTN_INTEROP
 ops_dat_core* ops_decl_dat_char(ops_block_core *, int, int *, int *, int *, int *, int *, char *,
                           int, char const *, char const *);
-void ops_decl_const_char(int, char const *, int, char *, char const *);
+void ops_decl_const_char(OPS_instance *, int, char const *, int, char *, char const *);
 OPS_FTN_INTEROP
 void ops_reduction_result_char(ops_reduction_core *handle, int type_size, char *ptr);
 /*

--- a/ops/c/include/ops_internal1.h
+++ b/ops/c/include/ops_internal1.h
@@ -95,6 +95,7 @@ ops_arg ops_arg_gbl_char(char *data, int dim, int size, ops_access acc);
 OPS_FTN_INTEROP
 ops_dat_core* ops_decl_dat_char(ops_block_core *, int, int *, int *, int *, int *, int *, char *,
                           int, char const *, char const *);
+template <typename T> void ops_decl_const2(char const *, int, char const *, T *);
 void ops_decl_const_char(OPS_instance *, int, char const *, int, char *, char const *);
 OPS_FTN_INTEROP
 void ops_reduction_result_char(ops_reduction_core *handle, int type_size, char *ptr);

--- a/ops/c/include/ops_internal2.h
+++ b/ops/c/include/ops_internal2.h
@@ -388,6 +388,13 @@ ops_dat ops_block_core::decl_dat(int data_size, int *block_size, int *base,
       stride, (char *)data, sizeof(T), type, name);
 }
 #endif
+
+template <typename T>
+void ops_decl_const2(char const *name, int dim, char const *type, T *data) {
+  ops_decl_const_char(OPS_instance::getOPSInstance(), dim, type, sizeof(T),
+                      (char *)data, name);
+}
+
 #endif
 
 #endif

--- a/ops/c/include/ops_internal2.h
+++ b/ops/c/include/ops_internal2.h
@@ -164,7 +164,6 @@ void ops_execute_reduction(ops_reduction handle);
 
 ops_arg ops_arg_reduce_core(ops_reduction handle, int dim, const char *type,
                             ops_access acc);
-void ops_decl_const_char(int, char const *, int, char *, char const *);
 
 void ops_init_core(OPS_instance *instance, const int argc, const char *const argv[], const int diags_level);
 
@@ -389,18 +388,6 @@ ops_dat ops_block_core::decl_dat(int data_size, int *block_size, int *base,
       stride, (char *)data, sizeof(T), type, name);
 }
 #endif
-
-template <class T>
-void ops_decl_const2(char const *name, int dim, char const *type, T *data) {
-  if (type_error(data, type)) {
-    OPSException ex(OPS_HDF5_ERROR);
-    ex << "Error: incorrect type specified for constant " << name;
-    throw ex;
-  }
-
-  ops_decl_const_char(dim, type, sizeof(T), (char *)data, name);
-}
 #endif
-
 
 #endif

--- a/ops/c/include/ops_internal2.h
+++ b/ops/c/include/ops_internal2.h
@@ -389,12 +389,13 @@ ops_dat ops_block_core::decl_dat(int data_size, int *block_size, int *base,
 }
 #endif
 
+#if !defined(OPS_CPP_API) || defined(OPS_INTERNAL_API)
 template <typename T>
 void ops_decl_const2(char const *name, int dim, char const *type, T *data) {
   ops_decl_const_char(OPS_instance::getOPSInstance(), dim, type, sizeof(T),
                       (char *)data, name);
 }
-
+#endif
 #endif
 
 #endif

--- a/ops/c/include/ops_lib_core.h
+++ b/ops/c/include/ops_lib_core.h
@@ -918,7 +918,7 @@ void ops_update_const(char const *name, int dim, char const *type, T *data) {
     ex << "Error: incorrect type specified for constant " << name << " in ops_update_const";
     throw ex;
   }
-  ops_decl_const_char(nullptr, dim, type, sizeof(T), (char *)data, name);
+  ops_decl_const2(name, dim, type, data);
 }
 
 /**
@@ -942,7 +942,7 @@ void ops_decl_const(char const *name, int dim, char const *type, T *data) {
     ex << "Error: incorrect type specified for constant " << name << " in ops_decl_const";
     throw ex;
   }
-  ops_decl_const_char(nullptr, dim, type, sizeof(T), (char*)data, name);
+  ops_decl_const2(name, dim, type, data);
 }
 
 #endif

--- a/ops/c/include/ops_lib_core.h
+++ b/ops/c/include/ops_lib_core.h
@@ -913,13 +913,12 @@ template <class T> void ops_reduction_result(ops_reduction handle, T *ptr) {
  */
 template <class T>
 void ops_update_const(char const *name, int dim, char const *type, T *data) {
-  (void)dim;
   if (type_error(data, type)) {
     OPSException ex(OPS_HDF5_ERROR);
     ex << "Error: incorrect type specified for constant " << name << " in ops_update_const";
     throw ex;
   }
-  ops_decl_const_char(dim, type, sizeof(T), (char *)data, name);
+  ops_decl_const_char(nullptr, dim, type, sizeof(T), (char *)data, name);
 }
 
 /**
@@ -938,13 +937,12 @@ void ops_update_const(char const *name, int dim, char const *type, T *data) {
  */
 template <class T>
 void ops_decl_const(char const *name, int dim, char const *type, T *data) {
-  (void)dim;
   if (type_error(data, type)) {
     OPSException ex(OPS_HDF5_ERROR);
     ex << "Error: incorrect type specified for constant " << name << " in ops_decl_const";
     throw ex;
   }
-  ops_decl_const_char(dim, type, sizeof(T), (char*)data, name);
+  ops_decl_const_char(nullptr, dim, type, sizeof(T), (char*)data, name);
 }
 
 #endif

--- a/ops/c/src/core/ops_instance.cpp
+++ b/ops/c/src/core/ops_instance.cpp
@@ -1,6 +1,6 @@
 #define OPS_CPP_API
 #define OPS_INTERNAL_API
-#include <ops_instance.h>
+#include <ops_lib_core.h>
 
 #include <atomic>
 

--- a/ops/c/src/core/ops_lib_core.cpp
+++ b/ops/c/src/core/ops_lib_core.cpp
@@ -38,7 +38,6 @@
   */
 
 #include <ops_lib_core.h>
-#include <ops_instance.h>
 #include <ops_exceptions.h>
 #include <float.h>
 #include <limits.h>

--- a/ops/c/src/mpi/ops_mpi_decl.cpp
+++ b/ops/c/src/mpi/ops_mpi_decl.cpp
@@ -199,11 +199,7 @@ void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,
   (void)typeSize;
   (void)data;
   (void)name;
-  if (instance) {
-    ops_execute(instance);
-  } else {
-    ops_execute(OPS_instance::getOPSInstance());
-  }
+  ops_execute(instance);
 }
 
 void ops_H_D_exchanges_host(ops_arg *args, int nargs) {

--- a/ops/c/src/mpi/ops_mpi_decl.cpp
+++ b/ops/c/src/mpi/ops_mpi_decl.cpp
@@ -194,16 +194,16 @@ void ops_NaNcheck(ops_dat dat) {
 
 void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,
                          int typeSize, char *data, char const *name) {
-    (void)dim;
-    (void)type;
-    (void)typeSize;
-    (void)data;
-    (void)name;
-    if (instance) {
-        ops_execute(instance);
-    } else {
-        ops_execute(OPS_instance::getOPSInstance());
-    }
+  (void)dim;
+  (void)type;
+  (void)typeSize;
+  (void)data;
+  (void)name;
+  if (instance) {
+    ops_execute(instance);
+  } else {
+    ops_execute(OPS_instance::getOPSInstance());
+  }
 }
 
 void ops_H_D_exchanges_host(ops_arg *args, int nargs) {

--- a/ops/c/src/mpi/ops_mpi_decl.cpp
+++ b/ops/c/src/mpi/ops_mpi_decl.cpp
@@ -192,15 +192,18 @@ void ops_NaNcheck(ops_dat dat) {
   }
 }
 
-
-void ops_decl_const_char(int dim, char const *type, int typeSize, char *data,
-                         char const *name) {
-  (void)dim;
-  (void)type;
-  (void)typeSize;
-  (void)data;
-  (void)name;
-  ops_execute(OPS_instance::getOPSInstance());
+void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,
+                         int typeSize, char *data, char const *name) {
+    (void)dim;
+    (void)type;
+    (void)typeSize;
+    (void)data;
+    (void)name;
+    if (instance) {
+        ops_execute(instance);
+    } else {
+        ops_execute(OPS_instance::getOPSInstance());
+    }
 }
 
 void ops_H_D_exchanges_host(ops_arg *args, int nargs) {

--- a/ops/c/src/sequential/ops_seq.cpp
+++ b/ops/c/src/sequential/ops_seq.cpp
@@ -572,16 +572,16 @@ void ops_dat_set_data_slab_memspace(ops_dat dat, int part, char *data, int *rang
 
 void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,
                          int typeSize, char *data, char const *name) {
-    (void)dim;
-    (void)type;
-    (void)typeSize;
-    (void)data;
-    (void)name;
-    if (instance) {
-        ops_execute(instance);
-    } else {
-        ops_execute(OPS_instance::getOPSInstance());
-    }
+  (void)dim;
+  (void)type;
+  (void)typeSize;
+  (void)data;
+  (void)name;
+  if (instance) {
+    ops_execute(instance);
+  } else {
+    ops_execute(OPS_instance::getOPSInstance());
+  }
 }
 
 void _ops_partition(OPS_instance *instance, const char *routine) {

--- a/ops/c/src/sequential/ops_seq.cpp
+++ b/ops/c/src/sequential/ops_seq.cpp
@@ -577,11 +577,7 @@ void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,
   (void)typeSize;
   (void)data;
   (void)name;
-  if (instance) {
-    ops_execute(instance);
-  } else {
-    ops_execute(OPS_instance::getOPSInstance());
-  }
+  ops_execute(instance);
 }
 
 void _ops_partition(OPS_instance *instance, const char *routine) {

--- a/ops/c/src/sequential/ops_seq.cpp
+++ b/ops/c/src/sequential/ops_seq.cpp
@@ -570,14 +570,18 @@ void ops_dat_set_data_slab_memspace(ops_dat dat, int part, char *data, int *rang
   ops_dat_set_data_slab_host(dat, part, data, range);
 }
 
-void ops_decl_const_char(int dim, char const *type, int typeSize, char *data,
-                         char const *name) {
-  (void)dim;
-  (void)type;
-  (void)typeSize;
-  (void)data;
-  (void)name;
-  ops_execute(OPS_instance::getOPSInstance());
+void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,
+                         int typeSize, char *data, char const *name) {
+    (void)dim;
+    (void)type;
+    (void)typeSize;
+    (void)data;
+    (void)name;
+    if (instance) {
+        ops_execute(instance);
+    } else {
+        ops_execute(OPS_instance::getOPSInstance());
+    }
 }
 
 void _ops_partition(OPS_instance *instance, const char *routine) {

--- a/ops_translator/c/ops.py
+++ b/ops_translator/c/ops.py
@@ -500,14 +500,6 @@ def main(source_files):
       if verbose:
         print((str(len(const_args))))
 
-      # cleanup '&' symbols from name and convert dim to integer
-      if const_args:
-        for i in range(0, len(const_args)):
-            #if const_args[i]['name2'][0] == '&':
-            const_args[i]['name2'] = const_args[i]['name2']
-            const_args[i]['dim'] = const_args[i]['dim']
-            const_args[i]['name'] = const_args[i]['name']
-
       # check for repeats
       nconsts = 0
       if const_args:
@@ -706,12 +698,6 @@ def main(source_files):
         header_len = 12
         loc_header = [text.find("ops_seq_v2.h")]
 
-      # get locations of all op_decl_consts
-      n_consts = len(const_args)
-      loc_consts = [0] * n_consts
-      for n in range(0, n_consts):
-          loc_consts[n] = const_args[n]['loc']
-
       # get locations of all ops_par_loops
       n_loops = len(loop_args)
       loc_loops = [0] * n_loops
@@ -729,7 +715,7 @@ def main(source_files):
         #loc_kernel_headers.append(match.end());
 
 
-      locs = sorted(loc_header + loc_consts + loc_loops + loc_kernel_headers)
+      locs = sorted(loc_header + loc_loops + loc_kernel_headers)
 
       # process header and loops
       for loc in range(0, len(locs)):
@@ -806,17 +792,6 @@ def main(source_files):
 
           fid.write(line[0:-len(indent) - 2] + ');')
 
-          loc_old = endofcall + 1
-          continue
-
-        if locs[loc] in loc_consts:
-          curr_const = loc_consts.index(locs[loc])
-          endofcall = text.find(';', locs[loc])
-          name = const_args[curr_const]['name']
-          fid.write(indent[0:-2] + 'ops_decl_const2( '+ name.strip() +
-            ',' + str(const_args[curr_const]['dim']) + ', "' +
-            const_args[curr_const]['type'] + '",' +
-            const_args[curr_const]['name2'].strip() + ');')
           loc_old = endofcall + 1
           continue
 

--- a/ops_translator/c/ops.py
+++ b/ops_translator/c/ops.py
@@ -212,7 +212,7 @@ def ops_decl_const_parse(text, macro_defs):
   """Parsing for ops_decl_const calls"""
 
   consts = []
-  for m in re.finditer('ops_decl_const\((.*)\)', text):
+  for m in re.finditer('(ops_|\.|->)decl_const\((.*)\)', text):
     args = m.group(1).split(',')
 
     # check for syntax errors

--- a/ops_translator/c/ops.py
+++ b/ops_translator/c/ops.py
@@ -213,7 +213,7 @@ def ops_decl_const_parse(text, macro_defs):
 
   consts = []
   for m in re.finditer('(ops_|\.|->)decl_const\((.*)\)', text):
-    args = m.group(1).split(',')
+    args = m.group(2).split(',')
 
     # check for syntax errors
     if len(args) != 4:

--- a/ops_translator/c/ops_gen_mpi_cuda.py
+++ b/ops_translator/c/ops_gen_mpi_cuda.py
@@ -1038,19 +1038,22 @@ def ops_gen_mpi_cuda(master, date, consts, kernels, soa_set):
   code('')
   code('void ops_init_backend() {}')
   code('')
-  code('void ops_decl_const_char(int dim, char const *type,')
+  code('void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,')
   code('int size, char *dat, char const *name){')
   config.depth = config.depth + 2
-  code('ops_execute(OPS_instance::getOPSInstance());')
+  IF('!instance')
+  code('instance = OPS_instance::getOPSInstance();')
+  ENDIF()
+  code('ops_execute(instance);')
 
   for nc in range(0,len(consts)):
     IF('!strcmp(name,"'+(str(consts[nc]['name']).replace('"','')).strip()+'")')
     if consts[nc]['dim'].isdigit():
-      code('cutilSafeCall(OPS_instance::getOPSInstance()->ostream(),cudaMemcpyToSymbol('+(str(consts[nc]['name']).replace('"','')).strip()+', dat, dim*size));')
+      code('cutilSafeCall(instance->ostream(),cudaMemcpyToSymbol('+(str(consts[nc]['name']).replace('"','')).strip()+', dat, dim*size));')
     else:
-      code('char *temp; cutilSafeCall(OPS_instance::getOPSInstance()->ostream(),cudaMalloc((void**)&temp,dim*size));')
-      code('cutilSafeCall(OPS_instance::getOPSInstance()->ostream(),cudaMemcpy(temp,dat,dim*size,cudaMemcpyHostToDevice));')
-      code('cutilSafeCall(OPS_instance::getOPSInstance()->ostream(),cudaMemcpyToSymbol('+(str(consts[nc]['name']).replace('"','')).strip()+', &temp, sizeof(char *)));')
+      code('char *temp; cutilSafeCall(instance->ostream(),cudaMalloc((void**)&temp,dim*size));')
+      code('cutilSafeCall(instance->ostream(),cudaMemcpy(temp,dat,dim*size,cudaMemcpyHostToDevice));')
+      code('cutilSafeCall(instance->ostream(),cudaMemcpyToSymbol('+(str(consts[nc]['name']).replace('"','')).strip()+', &temp, sizeof(char *)));')
     ENDIF()
     code('else')
 

--- a/ops_translator/c/ops_gen_mpi_cuda.py
+++ b/ops_translator/c/ops_gen_mpi_cuda.py
@@ -1041,9 +1041,6 @@ def ops_gen_mpi_cuda(master, date, consts, kernels, soa_set):
   code('void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,')
   code('int size, char *dat, char const *name){')
   config.depth = config.depth + 2
-  IF('!instance')
-  code('instance = OPS_instance::getOPSInstance();')
-  ENDIF()
   code('ops_execute(instance);')
 
   for nc in range(0,len(consts)):

--- a/ops_translator/c/ops_gen_mpi_hip.py
+++ b/ops_translator/c/ops_gen_mpi_hip.py
@@ -1031,19 +1031,22 @@ def ops_gen_mpi_hip(master, date, consts, kernels, soa_set):
     code('((int*)&'+str(consts[nc]['name']).replace('"','')+')[0]=0;')
   code('}')
   code('')
-  code('void ops_decl_const_char(int dim, char const *type,')
+  code('void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,')
   code('int size, char *dat, char const *name){')
   config.depth = config.depth + 2
-  code('ops_execute(OPS_instance::getOPSInstance());')
+  IF('!instance')
+  code('instance = OPS_instance::getOPSInstance();')
+  ENDIF()
+  code('ops_execute(instance);')
 
   for nc in range(0,len(consts)):
     IF('!strcmp(name,"'+(str(consts[nc]['name']).replace('"','')).strip()+'")')
     if consts[nc]['dim'].isdigit():
-      code('hipSafeCall(OPS_instance::getOPSInstance()->ostream(),hipMemcpyToSymbol(HIP_SYMBOL('+(str(consts[nc]['name']).replace('"','')).strip()+'_OPSCONSTANT), dat, dim*size));')
+      code('hipSafeCall(instance->ostream(),hipMemcpyToSymbol(HIP_SYMBOL('+(str(consts[nc]['name']).replace('"','')).strip()+'_OPSCONSTANT), dat, dim*size));')
     else:
-      code('char *temp; hipSafeCall(OPS_instance::getOPSInstance()->ostream(),hipMalloc((void**)&temp,dim*size));')
-      code('hipSafeCall(OPS_instance::getOPSInstance()->ostream(),hipMemcpy(temp,dat,dim*size,hipMemcpyHostToDevice));')
-      code('hipSafeCall(OPS_instance::getOPSInstance()->ostream(),hipMemcpyToSymbol(HIP_SYMBOL('+(str(consts[nc]['name']).replace('"','')).strip()+'_OPSCONSTANT), &temp, sizeof(char *)));')
+      code('char *temp; hipSafeCall(instance->ostream(),hipMalloc((void**)&temp,dim*size));')
+      code('hipSafeCall(instance->ostream(),hipMemcpy(temp,dat,dim*size,hipMemcpyHostToDevice));')
+      code('hipSafeCall(instance->ostream(),hipMemcpyToSymbol(HIP_SYMBOL('+(str(consts[nc]['name']).replace('"','')).strip()+'_OPSCONSTANT), &temp, sizeof(char *)));')
     ENDIF()
     code('else')
 

--- a/ops_translator/c/ops_gen_mpi_hip.py
+++ b/ops_translator/c/ops_gen_mpi_hip.py
@@ -1034,9 +1034,6 @@ def ops_gen_mpi_hip(master, date, consts, kernels, soa_set):
   code('void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,')
   code('int size, char *dat, char const *name){')
   config.depth = config.depth + 2
-  IF('!instance')
-  code('instance = OPS_instance::getOPSInstance();')
-  ENDIF()
   code('ops_execute(instance);')
 
   for nc in range(0,len(consts)):

--- a/ops_translator/c/ops_gen_mpi_inline.py
+++ b/ops_translator/c/ops_gen_mpi_inline.py
@@ -867,28 +867,6 @@ def ops_gen_mpi_inline(master, date, consts, kernels, soa_set):
   code('')
   code('void ops_init_backend() {}')
   code('')
-  code('void ops_decl_const_char2(int dim, char const *type,')
-  code('int size, char *dat, char const *name){')
-  config.depth = config.depth + 2
-
-  for nc in range(0,len(consts)):
-    IF('!strcmp(name,"'+(str(consts[nc]['name']).replace('"','')).strip()+'")')
-    if consts[nc]['dim'].isdigit() and int(consts[nc]['dim'])==1:
-      code((str(consts[nc]['name']).replace('"','')).strip()+' = *('+consts[nc]['type']+'*)dat;')
-    else:
-      code((str(consts[nc]['name']).replace('"','')).strip()+' = ('+consts[nc]['type']+'*)dat;')
-    ENDIF()
-    code('else')
-
-  code('{')
-  config.depth = config.depth + 2
-  code('throw OPSException(OPS_RUNTIME_ERROR, "error: unknown const name");')
-  ENDIF()
-
-  config.depth = config.depth - 2
-  code('}')
-  code('')
-  #code('')
   comm('user kernel files')
 
   kernel_name_list = []

--- a/ops_translator/c/ops_gen_mpi_openacc.py
+++ b/ops_translator/c/ops_gen_mpi_openacc.py
@@ -1012,10 +1012,13 @@ def ops_gen_mpi_openacc(master, date, consts, kernels, soa_set):
   code('')
   code('void ops_init_backend() {acc_set_device_num(ops_get_proc()%acc_get_num_devices(acc_device_nvidia),acc_device_nvidia); }')
   code('')
-  code('void ops_decl_const_char(int dim, char const *type,')
+  code('void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,')
   code('int size, char *dat, char const *name){')
   config.depth = config.depth + 2
-  code('ops_execute(OPS_instance::getOPSInstance());')
+  IF('!instance')
+  code('instance = OPS_instance::getOPSInstance();')
+  ENDIF()
+  code('ops_execute(instance);')
 
   for nc in range(0,len(consts)):
     IF('!strcmp(name,"'+(str(consts[nc]['name']).replace('"','')).strip()+'")')

--- a/ops_translator/c/ops_gen_mpi_openacc.py
+++ b/ops_translator/c/ops_gen_mpi_openacc.py
@@ -1015,9 +1015,6 @@ def ops_gen_mpi_openacc(master, date, consts, kernels, soa_set):
   code('void ops_decl_const_char(OPS_instance *instance, int dim, char const *type,')
   code('int size, char *dat, char const *name){')
   config.depth = config.depth + 2
-  IF('!instance')
-  code('instance = OPS_instance::getOPSInstance();')
-  ENDIF()
   code('ops_execute(instance);')
 
   for nc in range(0,len(consts)):

--- a/ops_translator/c/ops_gen_mpi_opencl.py
+++ b/ops_translator/c/ops_gen_mpi_opencl.py
@@ -1127,9 +1127,6 @@ def ops_gen_mpi_opencl(master, date, consts, kernels, soa_set):
   comm('this needs to be a platform specific copy symbol to device function')
   code('void ops_decl_const_char(OPS_instance *instance, int dim, char const * type, int typeSize, char * dat, char const * name ) {')
   config.depth =config.depth + 2
-  IF('!instance')
-  code('instance = OPS_instance::getOPSInstance();')
-  ENDIF()
   code('ops_execute(instance);')
   code('cl_int ret = 0;')
   IF('instance->opencl_instance->OPS_opencl_core.constant == NULL')

--- a/ops_translator/c/ops_gen_mpi_opencl.py
+++ b/ops_translator/c/ops_gen_mpi_opencl.py
@@ -1125,9 +1125,11 @@ def ops_gen_mpi_opencl(master, date, consts, kernels, soa_set):
   code('void ops_init_backend() {}')
   code('')
   comm('this needs to be a platform specific copy symbol to device function')
-  code('void ops_decl_const_char(int dim, char const * type, int typeSize, char * dat, char const * name ) {')
+  code('void ops_decl_const_char(OPS_instance *instance, int dim, char const * type, int typeSize, char * dat, char const * name ) {')
   config.depth =config.depth + 2
-  code('OPS_instance *instance = OPS_instance::getOPSInstance();')
+  IF('!instance')
+  code('instance = OPS_instance::getOPSInstance();')
+  ENDIF()
   code('ops_execute(instance);')
   code('cl_int ret = 0;')
   IF('instance->opencl_instance->OPS_opencl_core.constant == NULL')


### PR DESCRIPTION
Fix issue with OPS_instance::decl_const:
This function called a function that does not exist. Changed to call ops_decl_const_char and perform the same type checking as ops_decl_const.

Also cleans up unnecessary ops_decl_const2 function from code generator.

ops_instance.h:
  remove call to nonexisting function _ops_decl_const
  call ops_decl_const_char instead
ops_internal1.h:
  Add OPS_instance parameter to ops_decl_const_char
ops_internal2.h:
  Remove function declaration: function already declared in
  ops_internal1.h
  Remove ops_decl_const2: does the same as ops_decl_const
ops_lib_core.h:
  add OPS_instance parameters to ops_decl_const_char calls
ops_mpi_decl.cpp, ops_seq.cpp:
  Add check on instance parameter, call ops_execute on the correct
  instance.

ops.py:
  remove code replace on ops_decl_const (ops_decl_const2 removed)

ops_gen_mpi_inline.py:
  Remove ops_decl_const_char2 - never used.
ops_gen_mpi_<target>.py:
  Add instance parameter to generated ops_decl_const_char funcitons