### PR TITLE
Fix/tridsolver range

### DIFF
--- a/apps/c/adi/adi.cpp
+++ b/apps/c/adi/adi.cpp
@@ -401,21 +401,21 @@ int main(int argc, char *argv[]) {
 
     /**---- perform tri-diagonal solves in x-direction--**/
     ops_timers(&ct2, &et2);
-    ops_tridMultiDimBatch(3, 0, size, h_ax, h_bx, h_cx, h_du, trid_ctx_x);
+    ops_tridMultiDimBatch(3, 0, iter_range, h_ax, h_bx, h_cx, h_du, trid_ctx_x);
     ops_timers(&ct3, &et3);
     total_x += et3 - et2;
     //ops_printf("Elapsed trid_x (sec): %lf (s)\n", et3 - et2);
 
     /**---- perform tri-diagonal solves in y-direction--**/
     ops_timers(&ct2, &et2);
-    ops_tridMultiDimBatch(3, 1, size, h_ay, h_by, h_cy, h_du, trid_ctx_y);
+    ops_tridMultiDimBatch(3, 1, iter_range, h_ay, h_by, h_cy, h_du, trid_ctx_y);
     ops_timers(&ct3, &et3);
     total_y += et3 - et2;
     //ops_printf("Elapsed trid_y (sec): %lf (s)\n", et3 - et2);
 
     /**---- perform tri-diagonal solves in z-direction--**/
     ops_timers(&ct2, &et2);
-    ops_tridMultiDimBatch_Inc(3, 2, size, h_az, h_bz, h_cz, h_du, h_u, trid_ctx_z);
+    ops_tridMultiDimBatch_Inc(3, 2, iter_range, h_az, h_bz, h_cz, h_du, h_u, trid_ctx_z);
     ops_timers(&ct3, &et3);
     total_z += et3 - et2;
     //ops_printf("Elapsed trid_z (sec): %lf (s)\n", et3 - et2);

--- a/apps/c/adi_burger/adi_burger.cpp
+++ b/apps/c/adi_burger/adi_burger.cpp
@@ -179,8 +179,8 @@ int main(int argc, const char **argv) {
 
         /**---- perform tri-diagonal solves in x-direction--**/
         ops_timers(&ct2, &et2);
-        ops_tridMultiDimBatch_Inc(2, 0, size, a, b, c, du, uStar, trid_ctx);
-        ops_tridMultiDimBatch_Inc(2, 0, size, a, b, c, dv, vStar, trid_ctx);
+        ops_tridMultiDimBatch_Inc(2, 0, iterRange, a, b, c, du, uStar, trid_ctx);
+        ops_tridMultiDimBatch_Inc(2, 0, iterRange, a, b, c, dv, vStar, trid_ctx);
         ops_fetch_block_hdf5_file(burger2D, "adi_burger2D_X.h5");
         ops_fetch_dat_hdf5_file(u, "adi_burger2D_X.h5");
         ops_fetch_dat_hdf5_file(v, "adi_burger2D_X.h5");
@@ -212,8 +212,8 @@ int main(int argc, const char **argv) {
 
         /**---- perform tri-diagonal solves in y-direction--**/
         ops_timers(&ct2, &et2);
-        ops_tridMultiDimBatch_Inc(2, 1, size, a, b, c, du, u, trid_ctx);
-        ops_tridMultiDimBatch_Inc(2, 1, size, a, b, c, dv, v, trid_ctx);
+        ops_tridMultiDimBatch_Inc(2, 1, iterRange, a, b, c, du, u, trid_ctx);
+        ops_tridMultiDimBatch_Inc(2, 1, iterRange, a, b, c, dv, v, trid_ctx);
         ops_timers(&ct3, &et3);
         ops_printf("Elapsed trid_y (sec): %lf (s)\n", et3 - et2);
         ops_printf("Finish time=%lf\n", time);

--- a/apps/c/adi_burger_3D/adi_burger_3D.cpp
+++ b/apps/c/adi_burger_3D/adi_burger_3D.cpp
@@ -198,9 +198,9 @@ int main(int argc, char *argv[]) {
         // ops_printf("Elapsed preproc (sec): %lf (s)\n", et3 - et2);
         // perform tri-diagonal solves in x-direction
         ops_timers(&ct2, &et2);
-        ops_tridMultiDimBatch_Inc(3, 0, size, a, b, c, du, u, trid_ctx);
-        ops_tridMultiDimBatch_Inc(3, 0, size, a, b, c, dv, v, trid_ctx);
-        ops_tridMultiDimBatch_Inc(3, 0, size, a, b, c, dw, w, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 0, iterRange, a, b, c, du, u, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 0, iterRange, a, b, c, dv, v, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 0, iterRange, a, b, c, dw, w, trid_ctx);
         ops_timers(&ct3, &et3);
         totalX += et3 - et2;
         // WriteDataToH5("Burger3DX.h5", burger3D, debugList);
@@ -226,9 +226,9 @@ int main(int argc, char *argv[]) {
         // WriteDataToH5("Burger3DProcY.h5", burger3D, debugList);
         // perform tri-diagonal solves in y-direction
         ops_timers(&ct2, &et2);
-        ops_tridMultiDimBatch_Inc(3, 1, size, a, b, c, du, uStar, trid_ctx);
-        ops_tridMultiDimBatch_Inc(3, 1, size, a, b, c, dv, vStar, trid_ctx);
-        ops_tridMultiDimBatch_Inc(3, 1, size, a, b, c, dw, wStar, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 1, iterRange, a, b, c, du, uStar, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 1, iterRange, a, b, c, dv, vStar, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 1, iterRange, a, b, c, dw, wStar, trid_ctx);
         ops_timers(&ct3, &et3);
         totalY += et3 - et2;
         // WriteDataToH5("Burger3DY.h5", burger3D, debugList);
@@ -255,9 +255,9 @@ int main(int argc, char *argv[]) {
         // ops_printf("Elapsed preproc (sec): %lf (s)\n", et3 - et2);
         // perform tri-diagonal solves in Z-direction
         ops_timers(&ct2, &et2);
-        ops_tridMultiDimBatch_Inc(3, 2, size, a, b, c, du, u, trid_ctx);
-        ops_tridMultiDimBatch_Inc(3, 2, size, a, b, c, dv, v, trid_ctx);
-        ops_tridMultiDimBatch_Inc(3, 2, size, a, b, c, dw, w, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 2, iterRange, a, b, c, du, u, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 2, iterRange, a, b, c, dv, v, trid_ctx);
+        ops_tridMultiDimBatch_Inc(3, 2, iterRange, a, b, c, dw, w, trid_ctx);
         ops_timers(&ct3, &et3);
         totalZ += et3 - et2;
         //WriteDataToH5("Burger3DZ.h5", burger3D, debugList);

--- a/apps/c/compact_scheme/compact_scheme.cpp
+++ b/apps/c/compact_scheme/compact_scheme.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[]) {
                ops_arg_dat(d, 1, S3D_000, "double", OPS_WRITE), ops_arg_idx());
 
   // Get the u_x, note that the solver will add result to ux so that ux must be // zero before the call
-  ops_tridMultiDimBatch_Inc(3, 0, size, a, b, c, d, ux, trid_ctx);
+  ops_tridMultiDimBatch_Inc(3, 0, iterRange, a, b, c, d, ux, trid_ctx);
 
   ops_par_loop(preprocessY, "preprocessY", compact3d, 3, iterRange,
                ops_arg_dat(u, 1, S3D_7PT, "double", OPS_READ),
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
 
 
   // Get the u_y, note that the solver will add result to ux so that uy must be // zero before the call
-  ops_tridMultiDimBatch_Inc(3, 1, size, a, b, c, d, uy, trid_ctx);
+  ops_tridMultiDimBatch_Inc(3, 1, iterRange, a, b, c, d, uy, trid_ctx);
 
   ops_par_loop(preprocessZ, "preprocessZ", compact3d, 3, iterRange,
                ops_arg_dat(u, 1, S3D_7PT, "double", OPS_READ),
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
                ops_arg_dat(d, 1, S3D_000, "double", OPS_WRITE), ops_arg_idx());
 
   // Get the u_z, note that the solver will add result to ux so that ux must be // zero before the call
-  ops_tridMultiDimBatch_Inc(3, 2, size, a, b, c, d, uz, trid_ctx);
+  ops_tridMultiDimBatch_Inc(3, 2, iterRange, a, b, c, d, uz, trid_ctx);
 
   WriteDataToH5("Compact3D.h5", compact3d, resList);
   delete trid_ctx;

--- a/doc/opsapi.md
+++ b/doc/opsapi.md
@@ -791,7 +791,7 @@ Then parameters specific to different solving strategies can be set using setter
 
 ##### ops_tridMultiDimBatch
 
-__void ops_tridMultiDimBatch(int ndim, int solvedim, int* dims, ops_dat a, ops_dat b, ops_dat c, ops_dat d, ops_tridsolver_params *tridsolver_ctx)__
+__void ops_tridMultiDimBatch(int ndim, int solvedim, int* range, ops_dat a, ops_dat b, ops_dat c, ops_dat d, ops_tridsolver_params *tridsolver_ctx)__
 
 This solves multiple tridiagonal systems of equations in multidimensional datasets along the specified dimension. The matrix is stored in the `a` (bottom diagonal), `b` (central diagonal) and `c` (top diagonal) datasets. The right hand side is stored in the `d` dataset and the result is also written to this dataset.
 
@@ -799,7 +799,7 @@ This solves multiple tridiagonal systems of equations in multidimensional datase
 | ----------- | ----------- |
 |ndim| the dimension of the datasets |
 |solvedim| the dimension to solve along |
-|dims| the size of each dimension (excluding any padding) |
+|range| the range to solve over, similar to `ops_par_loop`'s range argument, cannot exclude an entire MPI process |
 |a| the dataset for the lower diagonal |
 |b| the dataset for the central diagonal |
 |c| the dataset for the upper diagonal |
@@ -808,7 +808,7 @@ This solves multiple tridiagonal systems of equations in multidimensional datase
 
 ##### ops_tridMultiDimBatch_Inc
 
-__void ops_tridMultiDimBatch(int ndim, int solvedim, int* dims, ops_dat a, ops_dat b, ops_dat c, ops_dat d, ops_dat u, ops_tridsolver_params *tridsolver_ctx)__
+__void ops_tridMultiDimBatch(int ndim, int solvedim, int* range, ops_dat a, ops_dat b, ops_dat c, ops_dat d, ops_dat u, ops_tridsolver_params *tridsolver_ctx)__
 
 This solves multiple tridiagonal systems of equations in multidimensional datasets along the specified dimension. The matrix is stored in the `a` (bottom diagonal), `b` (central diagonal) and `c` (top diagonal) datasets. The right hand side is stored in the `d` dataset and the result is added to the `u` dataset.
 
@@ -816,7 +816,7 @@ This solves multiple tridiagonal systems of equations in multidimensional datase
 | ----------- | ----------- |
 |ndim| the dimension of the datasets |
 |solvedim| the dimension to solve along |
-|dims| the size of each dimension (excluding any padding) |
+|dims| the range to solve over, similar to `ops_par_loop`'s range argument, cannot exclude an entire MPI process |
 |a| the dataset for the lower diagonal |
 |b| the dataset for the central diagonal |
 |c| the dataset for the upper diagonal |
@@ -828,24 +828,24 @@ This solves multiple tridiagonal systems of equations in multidimensional datase
 
 The following is a list of all the runtime flags and options that can be used when executing OPS generated applications.
 
-* `OPS_DIAGS=` : set OPS diagnostics level at runtime. 
+* `OPS_DIAGS=` : set OPS diagnostics level at runtime.
 
   `OPS_DIAGS=1` - no diagnostics, default level to achieve the best runtime performance.
-   
+
   `OPS_DIAGS>1` - print block decomposition and `ops_par_loop` timing breakdown.
-  
+
   `OPS_DIAGS>4` - print intra-block halo buffer allocation feedback (for OPS internal development only).
-  
+
   `OPS_DIAGS>5` - check if intra-block halo MPI sends depth match MPI receives depth (for OPS internal development only).  
-  
+
 * `OPS_BLOCK_SIZE_X=`, `OPS_BLOCK_SIZE_Y=` and `OPS_BLOCK_SIZE_Y=` : The CUDA (and OpenCL) thread block sizes in X, Y and Z dimensions. The sizes should be an integer between 1 - 1024, and currently they should be selected such that `OPS_BLOCK_SIZE_X`*`OPS_BLOCK_SIZE_Y`*`OPS_BLOCK_SIZE_Z`< 1024
 
-* `-gpudirect` : Enable GPU direct support when executing MPI+CUDA executables. 
+* `-gpudirect` : Enable GPU direct support when executing MPI+CUDA executables.
 
 * `OPS_CL_DEVICE=` : Select the OpenCL device for execution. Usually `OPS_CL_DEVICE=0` selects the CPU and `OPS_CL_DEVICE=1` selects GPUs. The selected device will be reported by OPS during execution.
 
-* `OPS_TILING` : Execute OpenMP code with cache blocking tiling. See the [Performance Tuning](https://github.com/OP-DSL/OPS/blob/MarkdownDocDev/doc/perf.md) section. 
-* `OPS_TILING_MAXDEPTH=` : Execute MPI+OpenMP code with cache blocking tiling and further communication avoidance. See the [Performance Tuning](https://github.com/OP-DSL/OPS/blob/MarkdownDocDev/doc/perf.md) section. 
+* `OPS_TILING` : Execute OpenMP code with cache blocking tiling. See the [Performance Tuning](https://github.com/OP-DSL/OPS/blob/MarkdownDocDev/doc/perf.md) section.
+* `OPS_TILING_MAXDEPTH=` : Execute MPI+OpenMP code with cache blocking tiling and further communication avoidance. See the [Performance Tuning](https://github.com/OP-DSL/OPS/blob/MarkdownDocDev/doc/perf.md) section.
 
 ## Doxygen
 Doxygen generated from OPS source can be found [here](https://op-dsl-ci.gitlab.io/ops-ci/).

--- a/ops/c/include/ops_tridiag.h
+++ b/ops/c/include/ops_tridiag.h
@@ -72,12 +72,12 @@ public:
 };
 
 OPS_FTN_INTEROP
-void ops_tridMultiDimBatch(int ndim, int solvedim, int* dims, ops_dat a,
+void ops_tridMultiDimBatch(int ndim, int solvedim, int* range, ops_dat a,
                            ops_dat b, ops_dat c, ops_dat d,
                            ops_tridsolver_params *tridsolver_ctx);
 
 OPS_FTN_INTEROP
-void ops_tridMultiDimBatch_Inc(int ndim, int solvedim, int* dims, ops_dat a,
+void ops_tridMultiDimBatch_Inc(int ndim, int solvedim, int* range, ops_dat a,
                                ops_dat b, ops_dat c, ops_dat d, ops_dat u,
                                ops_tridsolver_params *tridsolver_ctx);
 

--- a/ops/c/src/tridiag/ops_tridiag.cpp
+++ b/ops/c/src/tridiag/ops_tridiag.cpp
@@ -78,7 +78,7 @@ void ops_tridsolver_params::set_cuda_sync(int sync) {
 void ops_tridMultiDimBatch(
     int ndim,      // number of dimensions, ndim <= MAXDIM = 8
     int solvedim,  // user chosen dimension to perform solve
-    int *dims,     // array containing the sizes of each ndim dimensions
+    int *range,    // array containing the range over which to solve
     ops_dat a, ops_dat b, ops_dat c,  // left hand side coefficients of a
     // multidimensional problem. An array containing
     // A matrices of individual problems
@@ -104,6 +104,20 @@ void ops_tridMultiDimBatch(
   int s3D_000[] = {0, 0, 0};
   ops_stencil S3D_000 = ops_decl_stencil(3, 1, s3D_000, "000");
 
+  // Calculate dimension of area being solved and the starting offset from the
+  // origin of the dat
+  int dims[3];
+  int offset = 0;
+  for(int i = 0; i < ndim; i++) {
+    dims[i] = range[2 * i + 1] - range[2 * i];
+    if(i == 0)
+      offset += range[2 * i];
+    if(i == 1)
+      offset += range[2 * i] * a->size[0];
+    if(i == 2)
+      offset += range[2 * i] * a->size[1] * a->size[0];
+  }
+
   if(strcmp(a->type, "double") == 0) {
     const double *a_ptr = (double *)ops_dat_get_raw_pointer(a, 0, S3D_000, &host);
     const double *b_ptr = (double *)ops_dat_get_raw_pointer(b, 0, S3D_000, &host);
@@ -111,8 +125,8 @@ void ops_tridMultiDimBatch(
     double *d_ptr = (double *)ops_dat_get_raw_pointer(d, 0, S3D_000, &host);
 
     tridDmtsvStridedBatch((TridParams *)tridsolver_ctx->tridsolver_params,
-                          a_ptr, b_ptr, c_ptr, d_ptr, ndim, solvedim, dims,
-                          a->size);
+                          a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                          d_ptr + offset, ndim, solvedim, dims, a->size);
 
     ops_dat_release_raw_data(d, 0, OPS_RW);
     ops_dat_release_raw_data(c, 0, OPS_READ);
@@ -125,8 +139,8 @@ void ops_tridMultiDimBatch(
     float *d_ptr = (float *)ops_dat_get_raw_pointer(d, 0, S3D_000, &host);
 
     tridSmtsvStridedBatch((TridParams *)tridsolver_ctx->tridsolver_params,
-                          a_ptr, b_ptr, c_ptr, d_ptr, ndim, solvedim, dims,
-                          a->size);
+                          a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                          d_ptr + offset, ndim, solvedim, dims, a->size);
 
     ops_dat_release_raw_data(d, 0, OPS_RW);
     ops_dat_release_raw_data(c, 0, OPS_READ);
@@ -155,7 +169,7 @@ void ops_tridMultiDimBatch(
 void ops_tridMultiDimBatch_Inc(
     int ndim,      // number of dimensions, ndim <= MAXDIM = 8
     int solvedim,  // user chosen dimension to perform solve
-    int *dims,     // array containing the sizes of each ndim dimensions
+    int *range,    // array containing the range over which to solve
     ops_dat a, ops_dat b, ops_dat c,  // left hand side coefficients of a
     // multidimensional problem. An array containing
     // A matrices of individual problems
@@ -183,6 +197,20 @@ void ops_tridMultiDimBatch_Inc(
   int s3D_000[] = {0, 0, 0};
   ops_stencil S3D_000 = ops_decl_stencil(3, 1, s3D_000, "000");
 
+  // Calculate dimension of area being solved and the starting offset from the
+  // origin of the dat
+  int dims[3];
+  int offset = 0;
+  for(int i = 0; i < ndim; i++) {
+    dims[i] = range[2 * i + 1] - range[2 * i];
+    if(i == 0)
+      offset += range[2 * i];
+    if(i == 1)
+      offset += range[2 * i] * a->size[0];
+    if(i == 2)
+      offset += range[2 * i] * a->size[1] * a->size[0];
+  }
+
   if(strcmp(a->type, "double") == 0) {
     const double *a_ptr = (double *)ops_dat_get_raw_pointer(a, 0, S3D_000, &host);
     const double *b_ptr = (double *)ops_dat_get_raw_pointer(b, 0, S3D_000, &host);
@@ -191,7 +219,8 @@ void ops_tridMultiDimBatch_Inc(
     double *u_ptr = (double *)ops_dat_get_raw_pointer(u, 0, S3D_000, &host);
 
     tridDmtsvStridedBatchInc((TridParams *)tridsolver_ctx->tridsolver_params,
-                             a_ptr, b_ptr, c_ptr, d_ptr, u_ptr, ndim, solvedim,
+                             a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                             d_ptr + offset, u_ptr + offset, ndim, solvedim,
                              dims, a->size);
 
     ops_dat_release_raw_data(u, 0, OPS_RW);
@@ -207,7 +236,8 @@ void ops_tridMultiDimBatch_Inc(
     float *u_ptr = (float *)ops_dat_get_raw_pointer(u, 0, S3D_000, &host);
 
     tridSmtsvStridedBatchInc((TridParams *)tridsolver_ctx->tridsolver_params,
-                             a_ptr, b_ptr, c_ptr, d_ptr, u_ptr, ndim, solvedim,
+                             a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                             d_ptr + offset, u_ptr + offset, ndim, solvedim,
                              dims, a->size);
 
     ops_dat_release_raw_data(u, 0, OPS_RW);

--- a/ops/c/src/tridiag/ops_tridiag_mpi.cpp
+++ b/ops/c/src/tridiag/ops_tridiag_mpi.cpp
@@ -122,7 +122,7 @@ void ops_tridsolver_params::set_cuda_sync(int sync) {
 void ops_tridMultiDimBatch(
     int ndim,     // number of dimensions, ndim <= MAXDIM = 8
     int solvedim, // user chosen dimension to perform solve
-    int *dims,    // array containing the sizes of each ndim dimensions
+    int *range,   // array containing the range over which to solve
     ops_dat a, ops_dat b, ops_dat c, // left hand side coefficients of a
     // multidimensional problem. An array containing
     // A matrices of individual problems
@@ -144,15 +144,37 @@ void ops_tridMultiDimBatch(
     throw OPSException(OPS_RUNTIME_ERROR, "Tridsolver error: the a,b,c,d datasets must all be of the same type");
   }
 
-  int dims_calc[OPS_MAX_DIM];
-  int pads_m[OPS_MAX_DIM];
-  int pads_p[OPS_MAX_DIM];
-  sub_dat *sd_a = OPS_sub_dat_list[a->index];
-
+  // Will break if range exlcudes an entire MPI process
+  int offset = 0;
+  int dims_calc[3];
+  sub_dat_list sd = OPS_sub_dat_list[a->index];
   for(int i = 0; i < ndim; i++) {
-    pads_m[i] = -1 * (a->d_m[i] + sd_a->d_im[i]);
-    pads_p[i] = a->d_p[i] + sd_a->d_ip[i];
-    dims_calc[i] = a->size[i] - pads_m[i] - pads_p[i];
+    bool minRangeInSubDat = range[2 * i] >= sd->decomp_disp[i] && range[2 * i] < sd->decomp_disp[i] + sd->decomp_size[i];
+    bool maxRangeinSubDat = range[2 * i + 1] > sd->decomp_disp[i] && range[2 * i + 1] <= sd->decomp_disp[i] + sd->decomp_size[i];
+    // Check that range is within this sub_dat's global elements
+    // (otherwise no offset from sub_dat's origin needed for this dimension)
+    if(minRangeInSubDat) {
+      if(i == 0)
+        offset += range[2 * i];
+      if(i == 1)
+        offset += range[2 * i] * a->size[0];
+      if(i == 2)
+        offset += range[2 * i] * a->size[1] * a->size[0];
+    }
+
+    int pads_m = -1 * (a->d_m[i] + sd->d_im[i]);
+    int pads_p = a->d_p[i] + sd->d_ip[i];
+    dims_calc[i] = a->size[i] - pads_m - pads_p;
+
+    // Edit size of solve to include range information
+    if(minRangeInSubDat && maxRangeinSubDat) {
+      dims_calc[i] = range[2 * i + 1] - range[2 * i];
+    } else if(minRangeInSubDat) {
+      dims_calc[i] -= range[2 * i];
+    } else if(maxRangeinSubDat) {
+      int global_size = sd->gbl_size[i] - sd->gbl_d_p[i] + sd->gbl_d_m[i];
+      dims_calc[i] -= global_size - range[2 * i + 1];
+    }
   }
 
   int host = OPS_HOST;
@@ -168,8 +190,8 @@ void ops_tridMultiDimBatch(
     double *d_ptr = (double *)ops_dat_get_raw_pointer(d, 0, S3D_000, &host);
 
     tridDmtsvStridedBatch((TridParams *)tridsolver_ctx->tridsolver_params,
-                          a_ptr, b_ptr, c_ptr, d_ptr, ndim, solvedim, dims_calc,
-                          a->size);
+                          a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                          d_ptr + offset, ndim, solvedim, dims_calc, a->size);
 
     // Release pointer access back to OPS
     ops_dat_release_raw_data(d, 0, OPS_RW);
@@ -185,8 +207,8 @@ void ops_tridMultiDimBatch(
     float *d_ptr = (float *)ops_dat_get_raw_pointer(d, 0, S3D_000, &host);
 
     tridSmtsvStridedBatch((TridParams *)tridsolver_ctx->tridsolver_params,
-                          a_ptr, b_ptr, c_ptr, d_ptr, ndim, solvedim, dims_calc,
-                          a->size);
+                          a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                          d_ptr + offset, ndim, solvedim, dims_calc, a->size);
 
     // Release pointer access back to OPS
     ops_dat_release_raw_data(d, 0, OPS_RW);
@@ -201,7 +223,7 @@ void ops_tridMultiDimBatch(
 void ops_tridMultiDimBatch_Inc(
     int ndim,     // number of dimensions, ndim <= MAXDIM = 8
     int solvedim, // user chosen dimension to perform solve
-    int *dims,    // array containing the sizes of each ndim dimensions
+    int *range,   // array containing the range over which to solve
     ops_dat a, ops_dat b, ops_dat c, // left hand side coefficients of a
     // multidimensional problem. An array containing
     // A matrices of individual problems
@@ -224,15 +246,37 @@ void ops_tridMultiDimBatch_Inc(
     throw OPSException(OPS_RUNTIME_ERROR, "Tridsolver error: the a,b,c,d datasets must all be of the same type");
   }
 
-  int dims_calc[OPS_MAX_DIM];
-  int pads_m[OPS_MAX_DIM];
-  int pads_p[OPS_MAX_DIM];
-  sub_dat *sd_a = OPS_sub_dat_list[a->index];
-
+  // Will break if range exlcudes an entire MPI process
+  int offset = 0;
+  int dims_calc[3];
+  sub_dat_list sd = OPS_sub_dat_list[a->index];
   for(int i = 0; i < ndim; i++) {
-    pads_m[i] = -1 * (a->d_m[i] + sd_a->d_im[i]);
-    pads_p[i] = a->d_p[i] + sd_a->d_ip[i];
-    dims_calc[i] = a->size[i] - pads_m[i] - pads_p[i];
+    bool minRangeInSubDat = range[2 * i] >= sd->decomp_disp[i] && range[2 * i] < sd->decomp_disp[i] + sd->decomp_size[i];
+    bool maxRangeinSubDat = range[2 * i + 1] > sd->decomp_disp[i] && range[2 * i + 1] <= sd->decomp_disp[i] + sd->decomp_size[i];
+    // Check that range is within this sub_dat's global elements
+    // (otherwise no offset from sub_dat's origin needed for this dimension)
+    if(minRangeInSubDat) {
+      if(i == 0)
+        offset += range[2 * i];
+      if(i == 1)
+        offset += range[2 * i] * a->size[0];
+      if(i == 2)
+        offset += range[2 * i] * a->size[1] * a->size[0];
+    }
+
+    int pads_m = -1 * (a->d_m[i] + sd->d_im[i]);
+    int pads_p = a->d_p[i] + sd->d_ip[i];
+    dims_calc[i] = a->size[i] - pads_m - pads_p;
+
+    // Edit size of solve to include range information
+    if(minRangeInSubDat && maxRangeinSubDat) {
+      dims_calc[i] = range[2 * i + 1] - range[2 * i];
+    } else if(minRangeInSubDat) {
+      dims_calc[i] -= range[2 * i];
+    } else if(maxRangeinSubDat) {
+      int global_size = sd->gbl_size[i] - sd->gbl_d_p[i] + sd->gbl_d_m[i];
+      dims_calc[i] -= global_size - range[2 * i + 1];
+    }
   }
 
   int host = OPS_HOST;
@@ -248,7 +292,8 @@ void ops_tridMultiDimBatch_Inc(
 
     // For now do not consider adding padding
     tridDmtsvStridedBatchInc((TridParams *)tridsolver_ctx->tridsolver_params,
-                             a_ptr, b_ptr, c_ptr, d_ptr, u_ptr, ndim, solvedim,
+                             a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                             d_ptr + offset, u_ptr + offset, ndim, solvedim,
                              dims_calc, a->size);
 
     ops_dat_release_raw_data(u, 0, OPS_RW);
@@ -265,7 +310,8 @@ void ops_tridMultiDimBatch_Inc(
 
     // For now do not consider adding padding
     tridSmtsvStridedBatchInc((TridParams *)tridsolver_ctx->tridsolver_params,
-                             a_ptr, b_ptr, c_ptr, d_ptr, u_ptr, ndim, solvedim,
+                             a_ptr + offset, b_ptr + offset, c_ptr + offset,
+                             d_ptr + offset, u_ptr + offset, ndim, solvedim,
                              dims_calc, a->size);
 
     ops_dat_release_raw_data(u, 0, OPS_RW);


### PR DESCRIPTION
You can now specify the range over which to do the tridiagonal solve (in the same way as an ops_par_loop). This allows you to include the halo in tridsolver calls