### PR TITLE
Fix for intermittent HDF5 file opening issue over MPI

### DIFF
--- a/ops/c/src/mpi/ops_mpi_hdf5.cpp
+++ b/ops/c/src/mpi/ops_mpi_hdf5.cpp
@@ -287,7 +287,7 @@ void ops_fetch_block_hdf5_file(ops_block block, char const *file_name) {
       if (OPS_instance::getOPSInstance()->OPS_diags > 2)
         ops_printf("File %s does not exist .... creating file\n", file_name);
       MPI_Barrier(OPS_MPI_HDF5_BLOCK_WORLD);
-      if (ops_is_root()) {
+      if (my_rank==0) {
         FILE *fp;
         fp = fopen(file_name, "w");
         fclose(fp);

--- a/ops/c/src/mpi/ops_mpi_hdf5.cpp
+++ b/ops/c/src/mpi/ops_mpi_hdf5.cpp
@@ -286,6 +286,7 @@ void ops_fetch_block_hdf5_file(ops_block block, char const *file_name) {
     if (file_exist(file_name) == 0) {
       if (OPS_instance::getOPSInstance()->OPS_diags > 2)
         ops_printf("File %s does not exist .... creating file\n", file_name);
+      MPI_Barrier(OPS_MPI_HDF5_BLOCK_WORLD);
       if (ops_is_root()) {
         FILE *fp;
         fp = fopen(file_name, "w");


### PR DESCRIPTION
Adding a barrier before the file open command in the fetch_block_hdf5_file function has fixed the intermittent HDF5 file opening crashes I have been having over MPI. This works OK for multi-block cases over MPI. Tested on NVHPC V100 GPUs CUDA/MPI and Fujitsu A64FX MPI. 