### PR TITLE
free data in ops_fetch_dat

### DIFF
--- a/ops/c/src/externlib/ops_hdf5.cpp
+++ b/ops/c/src/externlib/ops_hdf5.cpp
@@ -632,7 +632,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
           throw ex;
       }
     }
-
+    free(data);
     H5Gclose(group_id);
     H5Fclose(file_id);
   }


### PR DESCRIPTION
This is a quick fix for the memory leaking issue during writing out data in HDF5 in sequencial mode. 