### PR TITLE
OpenMP Offload Support

### DIFF
--- a/makefiles/Makefile.c_app
+++ b/makefiles/Makefile.c_app
@@ -80,6 +80,8 @@ OMPOFFLOAD_KERNELS = $(MAIN_SRC)_ompoffload_kernels.cpp
 $(APP)_ompoffload: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_ompoffload.a $(OPS_FILES_GEN) $(HEADERS)
 	        $(CXX) $(OMPOFFLOADFLAGS) $(CXXFLAGS) -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./OpenMP_offload/$(OMPOFFLOAD_KERNELS) $(HDF5_LIB_SEQ) $(OPS_LINK) $(OPS_LIB_OMPOFFLOAD) -o $(APP)_ompoffload
 
+$(APP)_mpi_ompoffload: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_mpi_ompoffload.a $(OPS_FILES_GEN) $(HEADERS)
+	        $(MPICXX) -DOPS_MPI $(OMPOFFLOADFLAGS) $(CXXFLAGS) -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./OpenMP_offload/$(OMPOFFLOAD_KERNELS) $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI_OMPOFFLOAD) -o $(APP)_mpi_ompoffload
 
 #
 # Tiled version

--- a/makefiles/Makefile.clang
+++ b/makefiles/Makefile.clang
@@ -8,7 +8,41 @@ else
 	CXXFLAGS  := -O3 -fPIC -DUNIX -Wall -g -std=c++11
 endif
 OMPFLAGS=-fopenmp
-OMPOFFLOADFLAGS=-fopenmp -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_75
+OMPOFFLOADFLAGS=-fopenmp
 ifdef THREADED
 	THREADING_FLAGS ?= -fopenmp
+endif
+
+ifdef IEEE
+	CCFLAGS += -fno-fast-math -ffp-contract=off -fdenormal-fp-math=ieee -fno-associative-math
+	CXXFLAGS += -fno-fast-math -ffp-contract=off -fdenormal-fp-math=ieee -fno-associative-math
+endif
+
+ifndef NV_ARCH
+print:
+	@echo "select an NVIDA device to compile in CUDA, e.g. make NV_ARCH=Kepler"
+	NV_ARCH=Kepler
+endif
+ifeq ($(NV_ARCH),Fermi)
+	OMPOFFLOADFLAGS+= -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_20 -foffload-lto
+else
+ifeq ($(NV_ARCH),Kepler)
+	OMPOFFLOADFLAGS+= -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_35 -foffload-lto
+else
+ifeq ($(NV_ARCH),Pascal)
+	OMPOFFLOADFLAGS+= -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_60 -foffload-lto
+else
+ifeq ($(NV_ARCH),Volta)
+	OMPOFFLOADFLAGS+= -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_70 -foffload-lto
+else
+ifeq ($(NV_ARCH),Turing)
+	OMPOFFLOADFLAGS+= -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_75 -foffload-lto
+else
+ifeq ($(NV_ARCH),Ampere)
+	OMPOFFLOADFLAGS+= -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_80 -foffload-lto
+endif
+endif
+endif
+endif
+endif
 endif

--- a/makefiles/Makefile.clang
+++ b/makefiles/Makefile.clang
@@ -8,6 +8,7 @@ else
 	CXXFLAGS  := -O3 -fPIC -DUNIX -Wall -g -std=c++11
 endif
 OMPFLAGS=-fopenmp
+OMPOFFLOADFLAGS=-fopenmp -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_75
 ifdef THREADED
 	THREADING_FLAGS ?= -fopenmp
 endif

--- a/makefiles/Makefile.common
+++ b/makefiles/Makefile.common
@@ -27,6 +27,7 @@ OPS_LIB_MPI_HIP=-lops_mpi_hip
 OPS_LIB_SYCL=$(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_sycl.a
 OPS_LIB_MPI_SYCL=$(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_mpi_sycl.a
 OPS_LIB_OMPOFFLOAD=-lops_ompoffload
+OPS_LIB_MPI_OMPOFFLOAD=-lops_mpi_ompoffload
 OPS_LINK=
 CUDART=-lcudart
 

--- a/makefiles/Makefile.cuda
+++ b/makefiles/Makefile.cuda
@@ -24,9 +24,14 @@ ifeq ($(NV_ARCH),Volta)
         NVCCFLAGS+=-gencode arch=compute_70,code=sm_70
 				PGI_CUDA_FORT_FLAGS=-Mcuda=cc70
 else
+ifeq ($(NV_ARCH),Turing)
+        NVCCFLAGS+=-gencode arch=compute_75,code=sm_75
+                               PGI_CUDA_FORT_FLAGS=-Mcuda=cc75
+else
 ifeq ($(NV_ARCH),Ampere)
         NVCCFLAGS+=-gencode arch=compute_80,code=sm_80
         PGI_CUDA_FORT_FLAGS=-Mcuda=cc80
+endif
 endif
 endif
 endif

--- a/makefiles/Makefile.pgi
+++ b/makefiles/Makefile.pgi
@@ -19,6 +19,7 @@ FMODS         := -module $(F_INC_MOD)
 FMODS_CUDA    := -module $(F_INC_MOD)/cuda
 
 OMPFLAGS := -mp
+OMPOFFLOADFLAGS= -mp=gpu -Minfo=accel
 
 ifdef THREADED
 	THREADING_FLAGS ?= -mp

--- a/makefiles/Makefile.pgi
+++ b/makefiles/Makefile.pgi
@@ -19,7 +19,7 @@ FMODS         := -module $(F_INC_MOD)
 FMODS_CUDA    := -module $(F_INC_MOD)/cuda
 
 OMPFLAGS := -mp
-OMPOFFLOADFLAGS= -mp=gpu -Minfo=accel
+OMPOFFLOADFLAGS= -mp=gpu 
 
 ifdef THREADED
 	THREADING_FLAGS ?= -mp

--- a/ops/c/Makefile
+++ b/ops/c/Makefile
@@ -98,6 +98,9 @@ $(C_OPS_OBJ)/%_mpi.o : src/externlib/%.cpp
 $(C_OPS_OBJ)/%.o : src/ompoffload/%.cpp
 	$(CXX) $(CXXFLAGS) $(OMPOFFLOADFLAGS) -I$(C_OPS_INC) -c $< -o $@
 
+$(C_OPS_OBJ)/%_ompoffload_mpi.o : src/mpi/%_ompoffload.cpp
+	$(MPICXX) $(CXXFLAGS) $(OMPOFFLOADFLAGS) -I$(C_OPS_INC) $(MPI_INC) -c $< -o $@
+
 $(C_OPS_OBJ)/%_mpi.o : src/mpi/%.cpp
 	$(MPICXX) $(CXXFLAGS) $(OMPFLAGS) -I$(C_OPS_INC)  $(HDF5_INC) -c $< -o $@
 

--- a/ops/c/Makefile
+++ b/ops/c/Makefile
@@ -215,6 +215,15 @@ mpi_cuda: mklib $(C_OPS_OBJ)/ops_lib_core.o $(C_OPS_OBJ)/ops_instance.o $(C_OPS_
 	$(C_OPS_OBJ)/ops_mpi_core_mpi.o $(C_OPS_OBJ)/ops_mpi_rt_support_cuda.o $(C_OPS_OBJ)/ops_mpi_partition_mpi.o \
 	$(C_OPS_OBJ)/ops_cuda_rt_support.o $(C_OPS_OBJ)/ops_checkpointing_strategy.o $(C_OPS_OBJ)/ops_cuda_common.o
 
+mpi_ompoffload: mklib $(C_OPS_OBJ)/ops_lib_core.o $(C_OPS_OBJ)/ops_instance.o $(C_OPS_OBJ)/ops_lazy.o \
+  $(C_OPS_OBJ)/ops_checkpointing.o $(C_OPS_OBJ)/ops_util.o $(C_OPS_OBJ)/ops_mpi_decl_mpi.o $(C_OPS_OBJ)/ops_mpi_rt_support_mpi.o \
+  $(C_OPS_OBJ)/ops_mpi_core_mpi.o $(C_OPS_OBJ)/ops_mpi_rt_support_ompoffload_mpi.o $(C_OPS_OBJ)/ops_mpi_partition_mpi.o \
+  $(C_OPS_OBJ)/ops_checkpointing_strategy.o $(C_OPS_OBJ)/ops_ompoffload_common.o
+	ar -r $(C_OPS_LIB)/libops_mpi_ompoffload.a $(C_OPS_OBJ)/ops_lib_core.o $(C_OPS_OBJ)/ops_instance.o $(C_OPS_OBJ)/ops_lazy.o \
+	$(C_OPS_OBJ)/ops_checkpointing.o $(C_OPS_OBJ)/ops_util.o $(C_OPS_OBJ)/ops_mpi_decl_mpi.o $(C_OPS_OBJ)/ops_mpi_rt_support_mpi.o \
+	$(C_OPS_OBJ)/ops_mpi_core_mpi.o $(C_OPS_OBJ)/ops_mpi_rt_support_ompoffload_mpi.o $(C_OPS_OBJ)/ops_mpi_partition_mpi.o \
+	$(C_OPS_OBJ)/ops_checkpointing_strategy.o $(C_OPS_OBJ)/ops_ompoffload_common.o
+
 mpi_hip: mklib $(C_OPS_OBJ)/ops_lib_core.o $(C_OPS_OBJ)/ops_instance.o $(C_OPS_OBJ)/ops_lazy.o \
   $(C_OPS_OBJ)/ops_checkpointing.o $(C_OPS_OBJ)/ops_util.o $(C_OPS_OBJ)/ops_mpi_decl_mpi.o $(C_OPS_OBJ)/ops_mpi_rt_support_mpi.o \
   $(C_OPS_OBJ)/ops_mpi_core_mpi.o $(C_OPS_OBJ)/ops_mpi_rt_support_hip_mpi.o $(C_OPS_OBJ)/ops_mpi_partition_mpi.o \

--- a/ops/c/include/ops_internal2.h
+++ b/ops/c/include/ops_internal2.h
@@ -310,6 +310,9 @@ void ops_device_memcpy_d2d(OPS_instance *instance, void** to, void **from, size_
 void ops_device_memset(OPS_instance *instance, void** ptr, int val, size_t size);
 void ops_device_sync(OPS_instance *instance);
 void ops_exit_device(OPS_instance *instance);
+//
+void reallocConstArrays(OPS_instance *instance, int consts_bytes);
+void mvConstArraysToDevice(OPS_instance *instance, int consts_bytes);
 
 
 void _ops_init(OPS_instance *instance, const int argc, const char * const argv[], const int diags_level);

--- a/ops/c/src/mpi/ops_mpi_rt_support_ompoffload.cpp
+++ b/ops/c/src/mpi/ops_mpi_rt_support_ompoffload.cpp
@@ -1,0 +1,691 @@
+/*
+ * Open source copyright declaration based on BSD open source template:
+ * http://www.opensource.org/licenses/bsd-license.php
+ *
+ * This file is part of the OPS distribution.
+ *
+ * Copyright (c) 2013, Mike Giles and others. Please see the AUTHORS file in
+ * the main source directory for a full list of copyright holders.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * * The name of Mike Giles may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY Mike Giles ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Mike Giles BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file
+ * @brief OPS mpi+ompoffload run-time support routines
+ * @author Gihan Mudalige, Istvan Reguly
+ * @details Implements the runtime support routines for the OPS mpi+ompoffload
+ * backend
+ */
+#include <ops_lib_core.h>
+#include <ops_device_rt_support.h>
+
+int halo_buffer_size = 0;
+char *halo_buffer_d = NULL;
+
+void ops_exit_device(OPS_instance *instance) {
+	if (halo_buffer_d != NULL)
+		ops_device_free(instance, (void**)&halo_buffer_d);
+}
+
+void ops_pack_ompoffload_internal(ops_dat dat, const int src_offset,
+		char *__restrict dest, const int halo_blocklength,
+		const int halo_stride, const int halo_count) {
+
+	if (dat->dirty_hd == 1) {
+		ops_put_data(dat);
+		dat->dirty_hd = 0;
+	}
+
+	const char *__restrict src = dat->data_d + src_offset * (OPS_instance::getOPSInstance()->OPS_soa ? dat->type_size : dat->elem_size);
+
+	if (halo_buffer_size < halo_count * halo_blocklength * dat->dim && !OPS_instance::getOPSInstance()->OPS_gpu_direct) {
+		if (halo_buffer_d != NULL) {
+			ops_device_free(dat->block->instance, (void**)&halo_buffer_d);
+		}
+		ops_device_malloc(dat->block->instance, (void**)&halo_buffer_d, halo_count * halo_blocklength * dat->dim * 4);
+		halo_buffer_size = halo_count * halo_blocklength * dat->dim * 4;
+	}
+
+	char *dest_buff = NULL;
+	if (OPS_instance::getOPSInstance()->OPS_gpu_direct)
+		dest_buff = dest;
+	else
+		dest_buff = halo_buffer_d;
+
+
+	if (OPS_instance::getOPSInstance()->OPS_soa) {
+		int num_threads = 128;
+		int num_blocks = ((halo_blocklength * halo_count) - 1) / num_threads + 1;
+		size_t dat_size = dat->size[0] * dat->size[1] * dat->size[2] * dat->type_size;
+		int len = halo_blocklength;
+		int stride = halo_stride;
+
+		#pragma omp target teams distribute parallel for num_teams(num_blocks) thread_limit(num_threads)
+		for (int idx = 0; idx < num_threads * num_blocks; idx++) {
+			int block = idx / len;
+			if (idx < halo_count * len) {
+				for (int d = 0; d < dat->dim; d++) {
+					dest_buff[idx * dat->dim + d] = src[stride * block + idx % len + d * dat_size];
+				}
+			}
+		}
+	} else if (halo_blocklength % 4 == 0) {
+		int num_threads = 128;
+		int num_blocks = (((dat->dim * halo_blocklength / 4) * halo_count) - 1) / num_threads + 1;
+		int len = halo_blocklength * dat->dim / 4;
+		int stride = halo_stride * dat->dim / 4;
+
+		#pragma omp target teams distribute parallel for num_teams(num_blocks) thread_limit(num_threads)
+		for (int idx = 0; idx < num_threads * num_blocks; idx++) {
+			int block = idx / len;
+			if (idx < halo_count * len) {
+				dest_buff[idx] = src[stride * block + idx % len];
+			}
+		}
+	} else {
+		int num_threads = 128;
+		int num_blocks = ((dat->dim * halo_blocklength * halo_count) - 1) / num_threads + 1;
+		int len = halo_blocklength * dat->dim;
+		int stride = halo_stride * dat->dim;
+
+		#pragma omp target teams distribute parallel for num_teams(num_blocks) thread_limit(num_threads)
+		for (int idx = 0; idx < num_threads * num_blocks; idx++) {
+			int block = idx / len;
+			if (idx < halo_count * len) {
+				dest_buff[idx] = src[stride * block + idx % len];
+			}
+		}
+	}
+	if (!OPS_instance::getOPSInstance()->OPS_gpu_direct) {
+		ops_device_memcpy_d2h(dat->block->instance, (void**)&dest, (void**)&halo_buffer_d, halo_count * halo_blocklength * dat->dim);
+	} else
+		ops_device_sync(dat->block->instance);
+}
+
+void ops_unpack_ompoffload_internal(ops_dat dat, const int dest_offset, const char *__restrict src,
+                const int halo_blocklength, const int halo_stride, const int halo_count) {
+
+  if (dat->dirty_hd == 1) {
+    ops_put_data(dat);
+    dat->dirty_hd = 0;
+  }
+  char *__restrict dest = dat->data_d + dest_offset * (OPS_instance::getOPSInstance()->OPS_soa ? dat->type_size : dat->elem_size);
+  if (halo_buffer_size < halo_count * halo_blocklength * dat->dim && !OPS_instance::getOPSInstance()->OPS_gpu_direct) {
+		if (halo_buffer_d != NULL) {
+			ops_device_free(dat->block->instance, (void**)&halo_buffer_d);
+		}
+		ops_device_malloc(dat->block->instance, (void**)&halo_buffer_d, halo_count * halo_blocklength * dat->dim * 4);
+    halo_buffer_size = halo_count * halo_blocklength * dat->dim * 4;
+  }
+
+	const char *src_buff = NULL;
+	if (OPS_instance::getOPSInstance()->OPS_gpu_direct)
+		src_buff = src;
+	else
+		src_buff = halo_buffer_d;
+
+  if (!OPS_instance::getOPSInstance()->OPS_gpu_direct) {
+		ops_device_memcpy_h2d(dat->block->instance, (void**)&halo_buffer_d, (void**)&src, halo_count * halo_blocklength * dat->dim);
+	}
+
+  if (OPS_instance::getOPSInstance()->OPS_soa) {
+    int num_threads = 128;
+    int num_blocks = ((halo_blocklength * halo_count) - 1) / num_threads + 1;
+		size_t dat_size = dat->size[0] * dat->size[1] * dat->size[2] * dat->type_size;
+		int len = halo_blocklength;
+		int stride = halo_stride;
+
+		#pragma omp target teams distribute parallel for num_teams(num_blocks) thread_limit(num_threads)
+		for (int idx = 0; idx < num_threads * num_blocks; idx++) {
+			int block = idx / len;
+			if (idx < halo_count * len) {
+				for (int d = 0; d < dat->dim; d++) {
+					dest[stride * block + idx % len + d * dat_size] = src_buff[idx * dat->dim + d];
+				}
+			}
+		}
+  } else if (halo_blocklength % 4 == 0) {
+    int num_threads = 128;
+    int num_blocks = (((dat->dim * halo_blocklength / 4) * halo_count) - 1) / num_threads + 1;
+		int len = halo_blocklength * dat->dim / 4;
+		int stride = halo_stride * dat->dim / 4;
+
+		#pragma omp target teams distribute parallel for num_teams(num_blocks) thread_limit(num_threads)
+		for (int idx = 0; idx < num_threads * num_blocks; idx++) {
+			int block = idx / len;
+			if (idx < halo_count * len) {
+				dest[stride * block + idx % len] = src_buff[idx];
+			}
+		}
+
+  } else {
+    int num_threads = 128;
+    int num_blocks = ((dat->dim * halo_blocklength * halo_count) - 1) / num_threads + 1;
+		int len = halo_blocklength * dat->dim;
+		int stride = halo_stride * dat->dim;
+
+		#pragma omp target teams distribute parallel for num_teams(num_blocks) thread_limit(num_threads)
+		for (int idx = 0; idx < num_threads * num_blocks; idx++) {
+			int block = idx / len;
+			if (idx < halo_count * len) {
+				dest[stride * block + idx % len] = src_buff[idx];
+			}
+		}
+	}
+
+  dat->dirty_hd = 2;
+}
+
+void ops_halo_copy_tobuf(char *dest, int dest_offset, ops_dat src, int rx_s,
+		int rx_e, int ry_s, int ry_e, int rz_s, int rz_e,
+		int x_step, int y_step, int z_step, int buf_strides_x,
+		int buf_strides_y, int buf_strides_z) {
+
+  dest += dest_offset;
+  int thr_x = abs(rx_s - rx_e);
+  int blk_x = 1;
+  if (abs(rx_s - rx_e) > 8) {
+    blk_x = (thr_x - 1) / 8 + 1;
+    thr_x = 8;
+  }
+  int thr_y = abs(ry_s - ry_e);
+  int blk_y = 1;
+  if (abs(ry_s - ry_e) > 8) {
+    blk_y = (thr_y - 1) / 8 + 1;
+    thr_y = 8;
+  }
+  int thr_z = abs(rz_s - rz_e);
+  int blk_z = 1;
+  if (abs(rz_s - rz_e) > 8) {
+    blk_z = (thr_z - 1) / 8 + 1;
+    thr_z = 8;
+  }
+
+  int size = abs(src->elem_size * (rx_e - rx_s) * (ry_e - ry_s) * (rz_e - rz_s));
+
+	char *gpu_ptr;
+	if (OPS_instance::getOPSInstance()->OPS_gpu_direct)
+		gpu_ptr = dest;
+	else {
+		if (halo_buffer_size < size) {
+			if (halo_buffer_d != NULL) {
+				ops_device_free(src->block->instance, (void**)&halo_buffer_d);
+			}
+			ops_device_malloc(src->block->instance, (void**)&halo_buffer_d, size);
+			halo_buffer_size = size;
+		}
+		gpu_ptr = halo_buffer_d;
+	}
+
+	if (src->dirty_hd == 1) {
+		ops_put_data(src);
+		src->dirty_hd = 0;
+	}
+
+	char *src_buff = src->data_d;
+	int size_x = src->size[0];
+  int size_y = src->size[1];
+  int size_z = src->size[2];
+  int type_size = src->type_size;
+  int dim = src->dim;
+  int OPS_soa = src->block->instance->OPS_soa;
+
+	#pragma omp target teams distribute parallel for num_teams(blk_x * blk_y * blk_z) thread_limit(thr_x * thr_y * thr_z) collapse(3)
+	for (int x = 0; x < blk_x * thr_x; x++) {
+		for (int y = 0; y < blk_y * thr_y; y++) {
+			for (int z = 0; z < blk_z * thr_z; z++) {
+				int idx_z = rz_s + z_step * z;
+  			int idx_y = ry_s + y_step * y;
+  			int idx_x = rx_s + x_step * x;
+
+  			if ((x_step == 1 ? idx_x < rx_e : idx_x > rx_e) &&
+  			    (y_step == 1 ? idx_y < ry_e : idx_y > ry_e) &&
+  			    (z_step == 1 ? idx_z < rz_e : idx_z > rz_e)) {
+
+  			  if (OPS_soa) src_buff += (idx_z * size_x * size_y + idx_y * size_x + idx_x) * type_size;
+  			  else src_buff += (idx_z * size_x * size_y + idx_y * size_x + idx_x) * type_size * dim;
+  			  gpu_ptr += ((idx_z - rz_s) * z_step * buf_strides_z +
+  			           (idx_y - ry_s) * y_step * buf_strides_y +
+  			           (idx_x - rx_s) * x_step * buf_strides_x) *
+  			          type_size * dim ;
+  			  for (int d = 0; d < dim; d++) {
+  			    memcpy(gpu_ptr+d*type_size, src_buff, type_size);
+  			    if (OPS_soa) src_buff += size_x * size_y * size_z * type_size;
+  			    else src_buff += type_size;
+  			  }
+  			}
+			}
+		}
+	}
+
+	if (!OPS_instance::getOPSInstance()->OPS_gpu_direct) {
+		ops_device_memcpy_d2h(src->block->instance, (void**)&dest, (void**)&halo_buffer_d, size);
+	}
+}
+
+void ops_halo_copy_frombuf(ops_dat dest, char *src, int src_offset, int rx_s,
+                           int rx_e, int ry_s, int ry_e, int rz_s, int rz_e,
+                           int x_step, int y_step, int z_step,
+                           int buf_strides_x, int buf_strides_y,
+                           int buf_strides_z) {
+
+  src += src_offset;
+  int thr_x = abs(rx_s - rx_e);
+  int blk_x = 1;
+  if (abs(rx_s - rx_e) > 8) {
+    blk_x = (thr_x - 1) / 8 + 1;
+    thr_x = 8;
+  }
+  int thr_y = abs(ry_s - ry_e);
+  int blk_y = 1;
+  if (abs(ry_s - ry_e) > 8) {
+    blk_y = (thr_y - 1) / 8 + 1;
+    thr_y = 8;
+  }
+  int thr_z = abs(rz_s - rz_e);
+  int blk_z = 1;
+  if (abs(rz_s - rz_e) > 8) {
+    blk_z = (thr_z - 1) / 8 + 1;
+    thr_z = 8;
+  }
+
+  int size = abs(dest->elem_size * (rx_e - rx_s) * (ry_e - ry_s) * (rz_e - rz_s));
+  char *gpu_ptr;
+	if (OPS_instance::getOPSInstance()->OPS_gpu_direct)
+		gpu_ptr = src;
+	else {
+		if (halo_buffer_size < size) {
+			if (halo_buffer_d != NULL) {
+				ops_device_free(dest->block->instance, (void**)&halo_buffer_d);
+			}
+			ops_device_malloc(dest->block->instance, (void**)&halo_buffer_d, size);
+			halo_buffer_size = size;
+		}
+		gpu_ptr = halo_buffer_d;
+		ops_device_memcpy_h2d(dest->block->instance, (void**)&halo_buffer_d, (void**)&src, size);
+	}
+
+  if (dest->dirty_hd == 1) {
+    ops_put_data(dest);
+    dest->dirty_hd = 0;
+  }
+
+	char *dest_buff = dest->data_d;
+	int size_x = dest->size[0];
+  int size_y = dest->size[1];
+  int size_z = dest->size[2];
+  int type_size = dest->type_size;
+  int dim = dest->dim;
+  int OPS_soa = dest->block->instance->OPS_soa;
+
+	#pragma omp target teams distribute parallel for num_teams(blk_x * blk_y * blk_z) thread_limit(thr_x * thr_y * thr_z) collapse(3)
+	for (int x = 0; x < blk_x * thr_x; x++) {
+		for (int y = 0; y < blk_y * thr_y; y++) {
+			for (int z = 0; z < blk_z * thr_z; z++) {
+				int idx_z = rz_s + z_step * z;
+  			int idx_y = ry_s + y_step * y;
+  			int idx_x = rx_s + x_step * x;
+
+  			if ((x_step == 1 ? idx_x < rx_e : idx_x > rx_e) &&
+  			    (y_step == 1 ? idx_y < ry_e : idx_y > ry_e) &&
+  			    (z_step == 1 ? idx_z < rz_e : idx_z > rz_e)) {
+
+    			if (OPS_soa) dest_buff += (idx_z * size_x * size_y + idx_y * size_x + idx_x) * type_size;
+    			else dest_buff += (idx_z * size_x * size_y + idx_y * size_x + idx_x) * type_size * dim;
+    			gpu_ptr += ((idx_z - rz_s) * z_step * buf_strides_z +
+    			        (idx_y - ry_s) * y_step * buf_strides_y +
+    			        (idx_x - rx_s) * x_step * buf_strides_x) *
+    			       type_size * dim;
+  			  for (int d = 0; d < dim; d++) {
+      			memcpy(dest_buff, gpu_ptr + d * type_size, type_size);
+      			if (OPS_soa) dest_buff += size_x * size_y * size_z * type_size;
+      			else dest_buff += type_size;
+  			  }
+  			}
+			}
+		}
+	}
+	dest->dirty_hd = 2;
+}
+
+void ops_internal_copy_device(ops_kernel_descriptor *desc) {
+  int range[2*OPS_MAX_DIM]={0};
+  for (int d = 0; d < desc->dim; d++) {
+    range[2*d] = desc->range[2*d];
+    range[2*d+1] = desc->range[2*d+1];
+  }
+  for (int d = desc->dim; d < OPS_MAX_DIM; d++) {
+    range[2*d] = 0;
+    range[2*d+1] = 1;
+  }
+  ops_dat dat0 = desc->args[0].dat;
+  double __t1 = 0.,__t2 = 0.,__c1 = 0.,__c2 = 0.;
+  if (dat0->block->instance->OPS_diags>1) {
+    dat0->block->instance->OPS_kernels[-1].count++;
+    ops_timers_core(&__c1,&__t1);
+  }
+  char *dat0_p = desc->args[0].data_d + desc->args[0].dat->base_offset;
+  char *dat1_p = desc->args[1].data_d + desc->args[1].dat->base_offset;
+  int s0 = dat0->size[0];
+#if OPS_MAX_DIM>1
+  int s1 = dat0->size[1];
+#if OPS_MAX_DIM>2
+  int s2 = dat0->size[2];
+#if OPS_MAX_DIM>3
+  int s3 = dat0->size[3];
+#if OPS_MAX_DIM>4
+  int s4 = dat0->size[4];
+#endif
+#endif
+#endif
+#endif
+
+	int blk_x = (range[2*0+1]-range[2*0] - 1) / dat0->block->instance->OPS_block_size_x + 1;
+	int blk_y =  (range[2*1+1]-range[2*1] - 1) / dat0->block->instance->OPS_block_size_y + 1;
+	int blk_z = ((range[2*2+1]-range[2*2] - 1) / dat0->block->instance->OPS_block_size_z + 1) *
+		(range[2*3+1]-range[2*3]) *
+		(range[2*4+1]-range[2*4]);
+	int thr_x = dat0->block->instance->OPS_block_size_x;
+	int thr_y = dat0->block->instance->OPS_block_size_y;
+	int thr_z = dat0->block->instance->OPS_block_size_z;
+
+	int dim = dat0->dim;
+	int type_size = dat0->type_size;
+	int OPS_soa = dat0->block->instance->OPS_soa;
+	int start0 = range[2*0], end0 = range[2*0+1];
+#if OPS_MAX_DIM>1
+	int start1 = range[2*1], end1 = range[2*1+1];
+#if OPS_MAX_DIM>2
+	int start2 = range[2*2], end2 = range[2*2+1];
+#if OPS_MAX_DIM>3
+	int start3 = range[2*3], end3 = range[2*3+1];
+#if OPS_MAX_DIM>4
+	int start4 = range[2*4], end4 = range[2*4+1];
+#endif
+#endif
+#endif
+#endif
+
+	if (blk_x>0 && blk_y>0 && blk_z>0) {
+		#pragma omp target teams distribute parallel for num_teams(blk_x * blk_y * blk_z) thread_limit(thr_x * thr_y * thr_z) collapse(3)
+		for (int x = 0; x < blk_x * thr_x; x++) {
+			for (int y = 0; y < blk_y * thr_y; y++) {
+				for (int z = 0; z < blk_z * thr_z; z++) {
+					int i = start0 + x;
+  				int j = start1 + y;
+  				int rest = z;
+  				int mult = OPS_soa ? type_size : dim*type_size;
+
+    			long fullsize = s0;
+    			long idx = i*mult;
+#if OPS_MAX_DIM>1
+    			fullsize *= s1;
+    			idx += j * s0 * mult;
+#endif
+#if OPS_MAX_DIM>2
+    			fullsize *= s2;
+    			int k = start2+rest%s2;
+    			idx += k * s0 * s1 * mult;
+#endif
+#if OPS_MAX_DIM>3
+    			fullsize *= s3;
+    			int l = start3+rest/s2;
+    			idx += l * s0 * s1 * s2 * mult;
+#endif
+#if OPS_MAX_DIM>3
+    			fullsize *= s4;
+    			int m = start4+rest/(s2*s3);
+    			idx += m * s0 * s1 * s2 * s3 * mult;
+#endif
+    			if (i<end0
+#if OPS_MAX_DIM>1
+        			&& j < end1
+#if OPS_MAX_DIM>2
+        			&& k < end2
+#if OPS_MAX_DIM>3
+        			&& l < end3
+#if OPS_MAX_DIM>4
+        			&& m < end4
+#endif
+#endif
+#endif
+#endif
+       			) {
+						if (OPS_soa) {
+							for (int d = 0; d < dim; d++)
+								for (int c = 0; c < type_size; c++)
+									dat1_p[idx+d*fullsize*type_size+c] = dat0_p[idx+d*fullsize*type_size+c];
+						} else {
+							for (int d = 0; d < dim*type_size; d++)
+								dat1_p[idx+d] = dat0_p[idx+d];
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if (dat0->block->instance->OPS_diags>1) {
+		ops_device_sync(dat0->block->instance);
+		ops_timers_core(&__c2,&__t2);
+		int start[OPS_MAX_DIM];
+		int end[OPS_MAX_DIM];
+		for ( int n=0; n<desc->dim; n++ ){
+			start[n] = range[2*n];end[n] = range[2*n+1];
+		}
+		dat0->block->instance->OPS_kernels[-1].time += __t2-__t1;
+		dat0->block->instance->OPS_kernels[-1].transfer += ops_compute_transfer(desc->dim, start, end, &desc->args[0]);
+		dat0->block->instance->OPS_kernels[-1].transfer += ops_compute_transfer(desc->dim, start, end, &desc->args[1]);
+	}
+}
+
+void ops_dat_fetch_data_slab_memspace(ops_dat dat, int part, char *data, int *range, ops_memspace memspace) {
+	throw OPSException(OPS_NOT_IMPLEMENTED, "Error: Not implemented");
+	if (memspace == OPS_HOST) ops_dat_fetch_data_slab_host(dat, part, data, range);
+	else {
+		ops_execute(dat->block->instance);
+		int range2[2*OPS_MAX_DIM];
+		for (int i = 0; i < dat->block->dims; i++) {
+			range2[2*i] = range[2*i];
+			range2[2*i+1] = range[2*i+1];
+		}
+		for (int i = dat->block->dims; i < OPS_MAX_DIM; i++) {
+			range2[2*i] = 0;
+			range2[2*i+1] = 1;
+		}
+		if (dat->dirty_hd == 1) {
+			ops_put_data(dat);
+			dat->dirty_hd = 0;
+		}
+		ops_dat target = (ops_dat)ops_malloc(sizeof(ops_dat_core));
+		target->data_d = data;
+		target->elem_size = dat->elem_size;
+		target->base_offset = 0;
+		size_t prod = 1;
+		for (int d = 0; d < OPS_MAX_DIM; d++) {
+			target->size[d] = range2[2*d+1]-range2[2*d];
+			target->base_offset -= target->elem_size*prod*range2[2*d];
+			prod *= target->size[d];
+		}
+		ops_kernel_descriptor *desc = ops_dat_deep_copy_core(target, dat, range);
+    strcpy(desc->name, "ops_internal_copy_device\0");
+		desc->isdevice = 1;
+		desc->func = ops_internal_copy_device;
+		ops_internal_copy_device(desc);
+		target->data_d = NULL;
+		ops_free(target);
+		ops_free(desc->args);
+		ops_free(desc);
+	}
+
+}
+
+void ops_dat_set_data_slab_memspace(ops_dat dat, int part, char *data, int *range, ops_memspace memspace) {
+	throw OPSException(OPS_NOT_IMPLEMENTED, "Error: Not implemented");
+	if (memspace == OPS_HOST) ops_dat_set_data_slab_host(dat, part, data, range);
+	else {
+		ops_execute(dat->block->instance);
+		int range2[2*OPS_MAX_DIM];
+		for (int i = 0; i < dat->block->dims; i++) {
+			range2[2*i] = range[2*i];
+			range2[2*i+1] = range[2*i+1];
+		}
+		for (int i = dat->block->dims; i < OPS_MAX_DIM; i++) {
+			range2[2*i] = 0;
+			range2[2*i+1] = 1;
+		}
+		if (dat->dirty_hd == 1) {
+			ops_put_data(dat);
+			dat->dirty_hd = 0;
+		}
+		ops_dat target = (ops_dat)ops_malloc(sizeof(ops_dat_core));
+		target->data_d = data;
+		target->elem_size = dat->elem_size;
+		target->base_offset = 0;
+		size_t prod = 1;
+		for (int d = 0; d < OPS_MAX_DIM; d++) {
+			target->size[d] = range2[2*d+1]-range2[2*d];
+			target->base_offset -= target->elem_size*prod*range2[2*d];
+			prod *= target->size[d];
+		}
+		ops_kernel_descriptor *desc = ops_dat_deep_copy_core(target, dat, range);
+    strcpy(desc->name, "ops_internal_copy_device_reverse\0");
+		desc->isdevice = 1;
+		desc->func = ops_internal_copy_device;
+		ops_internal_copy_device(desc);
+		target->data_d = NULL;
+		ops_free(target);
+		ops_free(desc->args);
+		ops_free(desc);
+		dat->dirty_hd = 2;
+	}
+
+}
+
+
+void ops_dat_fetch_data_memspace(ops_dat dat, int part, char *data, ops_memspace memspace) {
+	throw OPSException(OPS_NOT_IMPLEMENTED, "Error: Not implemented");
+	if (memspace == OPS_HOST) ops_dat_fetch_data_host(dat, part, data);
+	else {
+		ops_execute(dat->block->instance);
+		int disp[OPS_MAX_DIM], size[OPS_MAX_DIM];
+		ops_dat_get_extents(dat, 0, disp, size);
+		int range[2*OPS_MAX_DIM];
+		for (int i = 0; i < dat->block->dims; i++) {
+			range[2*i] = dat->base[i];
+			range[2*i+1] = range[2*i] + size[i];
+		}
+		for (int i = dat->block->dims; i < OPS_MAX_DIM; i++) {
+			range[2*i] = 0;
+			range[2*i+1] = 1;
+		}
+		if (dat->dirty_hd == 1) {
+			ops_put_data(dat);
+			dat->dirty_hd = 0;
+		}
+		ops_dat target = (ops_dat)ops_malloc(sizeof(ops_dat_core));
+		target->data_d = data;
+		target->elem_size = dat->elem_size;
+		target->base_offset = 0;
+		for (int d = 0; d < OPS_MAX_DIM; d++) target->size[d] = size[d];
+		ops_kernel_descriptor *desc = ops_dat_deep_copy_core(target, dat, range);
+    strcpy(desc->name, "ops_internal_copy_device\0");
+		desc->isdevice = 1;
+		desc->func = ops_internal_copy_device;
+		ops_internal_copy_device(desc);
+		target->data_d = NULL;
+		ops_free(target);
+		ops_free(desc->args);
+		ops_free(desc);
+	}
+}
+
+void ops_dat_set_data_memspace(ops_dat dat, int part, char *data, ops_memspace memspace) {
+	throw OPSException(OPS_NOT_IMPLEMENTED, "Error: Not implemented");
+	if (memspace == OPS_HOST) ops_dat_set_data_host(dat, part, data);
+	else {
+		ops_execute(dat->block->instance);
+		int disp[OPS_MAX_DIM], size[OPS_MAX_DIM];
+		ops_dat_get_extents(dat, 0, disp, size);
+		int range[2*OPS_MAX_DIM];
+		for (int i = 0; i < dat->block->dims; i++) {
+			range[2*i] = dat->base[i];
+			range[2*i+1] = range[2*i] + size[i];
+		}
+		for (int i = dat->block->dims; i < OPS_MAX_DIM; i++) {
+			range[2*i] = 0;
+			range[2*i+1] = 1;
+		}
+		if (dat->dirty_hd == 1)
+			ops_put_data(dat);
+		ops_dat target = (ops_dat)ops_malloc(sizeof(ops_dat_core));
+		target->data_d = data;
+		target->elem_size = dat->elem_size;
+		target->base_offset = 0;
+		for (int d = 0; d < OPS_MAX_DIM; d++) target->size[d] = size[d];
+		ops_kernel_descriptor *desc = ops_dat_deep_copy_core(target, dat, range);
+    strcpy(desc->name, "ops_internal_copy_device_reverse\0");
+		desc->isdevice = 1;
+		desc->func = ops_internal_copy_device;
+		ops_internal_copy_device(desc);
+		target->data_d = NULL;
+		ops_free(target);
+		ops_free(desc->args);
+		ops_free(desc);
+		dat->dirty_hd = 2;
+	}
+}
+
+
+void ops_pack(ops_dat dat, const int src_offset, char *__restrict dest,
+		const ops_int_halo *__restrict halo) {
+	ops_pack_ompoffload_internal(dat,  src_offset, dest, halo->blocklength, halo->stride, halo->count);
+}
+void ops_unpack(ops_dat dat, const int dest_offset, const char *__restrict src,
+		const ops_int_halo *__restrict halo) {
+	ops_unpack_ompoffload_internal(dat,  dest_offset, src, halo->blocklength, halo->stride, halo->count);
+}
+
+
+char* OPS_realloc_fast(char *ptr, size_t olds, size_t news) {
+	if (OPS_instance::getOPSInstance()->OPS_gpu_direct) {
+		if (ptr == NULL) {
+			ops_device_malloc(OPS_instance::getOPSInstance(), (void **)&ptr, news);
+			return ptr;
+		} else {
+			if (OPS_instance::getOPSInstance()->OPS_diags>3) printf("Warning: OpenMP Offload cache realloc\n");
+			char *ptr2;
+			ops_device_malloc(OPS_instance::getOPSInstance(), (void **)&ptr2, news);
+			ops_device_memcpy_d2d(OPS_instance::getOPSInstance(), (void **)&ptr2, (void **)&ptr, olds);
+			ops_device_free(OPS_instance::getOPSInstance(), (void **)&ptr);
+			return ptr2;
+		}
+	} else {
+		char *ptr2;
+		ops_device_mallochost(OPS_instance::getOPSInstance(), (void **)&ptr2, news);
+		if (olds > 0)
+			memcpy(ptr2, ptr, olds);
+		if (ptr != NULL) ops_device_free(OPS_instance::getOPSInstance(), (void **)&ptr);
+		return ptr2;
+	}
+}

--- a/ops/c/src/ompoffload/ops_ompoffload_common.cpp
+++ b/ops/c/src/ompoffload/ops_ompoffload_common.cpp
@@ -57,7 +57,7 @@ void ops_init_device(OPS_instance *instance, const int argc, const char *const a
 void ops_device_malloc(OPS_instance *instance, void** ptr, size_t bytes) {
   *ptr = ops_malloc(bytes);
   char *ptr2 = (char *)*ptr;
-  #pragma omp target enter data map(to: ptr2[:bytes])
+  #pragma omp target enter data map(alloc: ptr2[:bytes])
   //#pragma omp target update to((*ptr)[:bytes])
 }
 
@@ -67,7 +67,7 @@ void ops_device_mallochost(OPS_instance *instance, void** ptr, size_t bytes) {
 
 void ops_device_free(OPS_instance *instance, void** ptr) {
   char *ptr2 = (char *)*ptr;
-  #pragma omp target exit data map(from: ptr)
+  #pragma omp target exit data map(delete: ptr2)
   ops_free(*ptr);
   *ptr = nullptr;
 }

--- a/ops/c/src/ompoffload/ops_ompoffload_common.cpp
+++ b/ops/c/src/ompoffload/ops_ompoffload_common.cpp
@@ -56,9 +56,10 @@ void ops_init_device(OPS_instance *instance, const int argc, const char *const a
 
 void ops_device_malloc(OPS_instance *instance, void** ptr, size_t bytes) {
   *ptr = ops_malloc(bytes);
-  char *ptr2 = (char *)*ptr;
-  #pragma omp target enter data map(alloc: ptr2[:bytes])
-  //#pragma omp target update to((*ptr)[:bytes])
+  int device = omp_get_default_device();
+
+  void* device_ptr = omp_target_alloc(bytes, device);
+  omp_target_associate_ptr(*ptr, device_ptr, bytes, 0, device);
 }
 
 void ops_device_mallochost(OPS_instance *instance, void** ptr, size_t bytes) {
@@ -66,8 +67,11 @@ void ops_device_mallochost(OPS_instance *instance, void** ptr, size_t bytes) {
 }
 
 void ops_device_free(OPS_instance *instance, void** ptr) {
-  char *ptr2 = (char *)*ptr;
-  #pragma omp target exit data map(delete: ptr2)
+  int device = omp_get_default_device();
+
+  void* device_ptr = omp_get_mapped_ptr(*ptr, device); 
+  omp_target_disassociate_ptr(*ptr, device);
+  omp_target_free(device_ptr, device);
   ops_free(*ptr);
   *ptr = nullptr;
 }
@@ -78,32 +82,47 @@ void ops_device_freehost(OPS_instance *instance, void** ptr) {
 }
 
 void ops_device_memcpy_h2d(OPS_instance *instance, void** to, void **from, size_t size) {
-  memcpy(*to, *from, size);
-  char *ptr2 = (char *)*to;
-  #pragma omp target update to(ptr2[:size])
+  int host = omp_get_initial_device();
+  int device = omp_get_default_device();
+
+  void* device_ptr = omp_get_mapped_ptr(*to, device);
+  omp_target_memcpy(device_ptr, *from, size, 0, 0, device, host);
 }
 
 void ops_device_memcpy_d2h(OPS_instance *instance, void** to, void **from, size_t size) {
-  char *ptr2 = (char *)*from;
-  #pragma omp target update from(ptr2[:size])
-  memcpy(*to, *from, size);
+  int host = omp_get_initial_device();
+  int device = omp_get_default_device();
+
+  void* device_ptr = omp_get_mapped_ptr(*from, device);
+  omp_target_memcpy(*to, device_ptr, size, 0, 0, host, device);
 }
 
 void ops_device_memcpy_d2d(OPS_instance *instance, void** to, void **from, size_t size) {
-  char *ptr = (char *)*to;
-  char *ptr2 = (char *)*from;
-  #pragma omp target teams distribute parallel for map(to: ptr[:size]) map(from: ptr2[:size])
-  for (int i = 0; i < size; i++) {
-    ptr[i] = ptr2[i];
+  int device, device2;
+  int no_devices = omp_get_num_devices();
+
+  for(int i = 0; i < no_devices; i++) {
+    if (omp_target_is_present(*from, i)) {
+	device = i;
+    }
+    if (omp_target_is_present(*to, i)) {
+	device2 = i;
+    }
   }
+
+  void* device_ptr = omp_get_mapped_ptr(*from, device);
+  void* device_ptr2 = omp_get_mapped_ptr(*to, device);
+  omp_target_memcpy(device_ptr2, device_ptr, size, 0, 0, device2, device);
 }
 
 void ops_device_memset(OPS_instance *instance, void** ptr, int val, size_t size) {
-    char *ptr2 = (char *)*ptr;
-    #pragma omp target teams distribute parallel for map(to: ptr2[:size])
-    for (int i = 0; i < size; i++) {
-      ptr2[i] = (char)val;
-    }
+  int device = omp_get_default_device();
+
+  char* ptr2 = (char*) omp_get_mapped_ptr(*ptr, device);
+  #pragma omp target teams distribute parallel for is_device_ptr(ptr2)
+  for (int i = 0; i < size; i++) {
+    ptr2[i] = (char)val;
+  }
 }
 
 void ops_device_sync(OPS_instance *instance) {

--- a/ops/c/src/ompoffload/ops_ompoffload_common.cpp
+++ b/ops/c/src/ompoffload/ops_ompoffload_common.cpp
@@ -51,6 +51,9 @@ void ops_init_device(OPS_instance *instance, const int argc, const char *const a
     throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: OPS_block_size_x*OPS_block_size_y*OPS_block_size_z should be less than 1024 -- error OPS_block_size_*");
   }
   cutilDeviceInit(instance, argc, argv);
+  int my_id = ops_get_proc();
+  int no_of_devices = omp_get_num_devices();
+  omp_set_default_device(my_id % no_of_devices);
   instance->OPS_hybrid_gpu = 1;
 }
 
@@ -118,8 +121,8 @@ void ops_device_memcpy_d2d(OPS_instance *instance, void** to, void **from, size_
 void ops_device_memset(OPS_instance *instance, void** ptr, int val, size_t size) {
   int device = omp_get_default_device();
 
-  char* ptr2 = (char*) omp_get_mapped_ptr(*ptr, device);
-  #pragma omp target teams distribute parallel for is_device_ptr(ptr2)
+  char* ptr2 = (char*) *ptr;
+  #pragma omp target teams distribute parallel for
   for (int i = 0; i < size; i++) {
     ptr2[i] = (char)val;
   }

--- a/ops/c/src/ompoffload/ops_ompoffload_rt_support_kernels.cpp
+++ b/ops/c/src/ompoffload/ops_ompoffload_rt_support_kernels.cpp
@@ -64,7 +64,7 @@ void ops_halo_copy_tobuf(char *dest, int dest_offset, ops_dat src, int rx_s,
   int size_z = src->size[2];
   int dim = src->dim;
   
-#pragma omp target teams distribute parallel for collapse(3) map(to: srcptr[0:src->mem]) map(tofrom: dest[0:bufsize]) private(srcptr,dest)
+#pragma omp target teams distribute parallel for collapse(3)
   for (int k = 0; k < thr_z; k++) {
     for (int j = 0; j < thr_y; j++) {
       for (int i = 0; i < thr_x; i++) {
@@ -113,7 +113,7 @@ void ops_halo_copy_frombuf(ops_dat dest, char *src, int src_offset, int rx_s,
   int size_z = dest->size[2];
   int dim = dest->dim;
 
-#pragma omp target teams distribute parallel for collapse(3) map(to: src[0:bufsize]) map(tofrom: dest->data_d[0:dest->mem]) private(destptr,src)
+#pragma omp target teams distribute parallel for collapse(3)
   for (int k = 0; k < thr_z; k++) {
     for (int j = 0; j < thr_y; j++) {
       for (int i = 0; i < thr_x; i++) {

--- a/ops_translator/c/ops_gen_mpi_lazy.py
+++ b/ops_translator/c/ops_gen_mpi_lazy.py
@@ -327,7 +327,8 @@ def ops_gen_mpi_lazy(master, consts, kernels, soa_set, offload=0):
         else:
             for g_m in range(0,nargs):
                 if arg_typ[g_m] == "ops_arg_dat":
-                    line2 += f" map({'to' if accs[g_m] == OPS_READ else 'tofrom'}:{arg_list[g_m]}_p[0:arg{g_m}_size])"
+                    pass
+                    #line2 += f" map({'to' if accs[g_m] == OPS_READ else 'tofrom'}:{arg_list[g_m]}_p[0:arg{g_m}_size])"
                 elif arg_typ[g_m] == "ops_arg_gbl" and accs[g_m] == OPS_READ:
                     line2 += f" map(to:{clean_type(arg_list[g_m])}[0:{dims[g_m]}])"
             for n in range(0, nargs):

--- a/ops_translator/c/ops_gen_mpi_lazy.py
+++ b/ops_translator/c/ops_gen_mpi_lazy.py
@@ -330,6 +330,13 @@ def ops_gen_mpi_lazy(master, consts, kernels, soa_set, offload=0):
                     line2 += f" map({'to' if accs[g_m] == OPS_READ else 'tofrom'}:{arg_list[g_m]}_p[0:arg{g_m}_size])"
                 elif arg_typ[g_m] == "ops_arg_gbl" and accs[g_m] == OPS_READ:
                     line2 += f" map(to:{clean_type(arg_list[g_m])}[0:{dims[g_m]}])"
+            for n in range(0, nargs):
+                if arg_typ[n] == "ops_arg_gbl":
+                    if accs[n] == OPS_MIN:
+                        line2 += f" map(to:p_a{n}[0:{int(dims[n])}])"
+                    if accs[n] == OPS_MAX:
+                        line2 += f" map(to:p_a{n}[0:{int(dims[n])}])"
+
             code(f"#pragma omp target teams distribute parallel for collapse({NDIM})" + line2)
         if NDIM > 2:
             FOR("n_z", "start[2]", "end[2]")


### PR DESCRIPTION
This PR addresses the OpenMP Offload support for OPS.
Changelog:
* Added support for OpenMP Offload MPI backend
* Changed the pragmas to runtime function calls for better debugging and performance
* Use of device pointer association to host for easier development and less remapping (unified shared memory)
* Removal of excess map clauses since the use of unified shared memory
* changes to the makefiles