### PR TITLE
Clean up a few inconsistencies in makefiles.

### DIFF
--- a/makefiles/Makefile.c_app
+++ b/makefiles/Makefile.c_app
@@ -41,18 +41,18 @@ endif
 all: $(TARGETS)
 
 $(APP)_dev_seq: Makefile $(HEADERS) $(OPS_FILES_PLAIN) $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_seq.a
-		$(CXX) $(CXXFLAGS) -std=c++11 -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_PLAIN) $(HDF5_LIB_SEQ) $(OPS_LINK) $(OPS_LIB_SEQ) $(TRID_SEQ) -fopenmp -o $(APP)_dev_seq
+		$(CXX) $(CXXFLAGS) -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_PLAIN) $(HDF5_LIB_SEQ) $(OPS_LINK) $(OPS_LIB_SEQ) $(TRID_SEQ) -o $(APP)_dev_seq
 
 $(APP)_dev_mpi: Makefile $(OPS_FILES_PLAIN) \
                 $(HEADERS) $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_mpi.a
-	        $(MPICPP) $(CXXFLAGS) -DOPS_MPI -std=c++11 -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_PLAIN) $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI) $(TRID_MPI) -fopenmp -o $(APP)_dev_mpi
+	        $(MPICPP) $(CXXFLAGS) -DOPS_MPI -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_PLAIN) $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI) $(TRID_MPI) -o $(APP)_dev_mpi
 
 
 #
 # Sequential version
 #
 $(APP)_seq: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_seq.a $(OPS_FILES_GEN) $(HEADERS)
-		$(MPICPP) $(CXXFLAGS) -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_SEQ) $(OPS_LINK) $(OPS_LIB_SEQ) $(TRID_SEQ) -fopenmp -o $(APP)_seq
+		$(MPICPP) $(CXXFLAGS) $(OMPFLAGS) -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_SEQ) $(OPS_LINK) $(OPS_LIB_SEQ) $(TRID_SEQ) -o $(APP)_seq
 
 
 #
@@ -62,7 +62,7 @@ $(APP)_seq: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops
 SEQ_KERNELS = $(MAIN_SRC)_cpu_kernels.cpp
 
 $(APP)_mpi: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_mpi.a
-	        $(MPICPP) $(CXXFLAGS) -DOPS_MPI -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI) $(TRID_MPI) -fopenmp -o $(APP)_mpi
+	        $(MPICPP) $(CXXFLAGS) $(OMPFLAGS) -DOPS_MPI -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI) $(TRID_MPI) -o $(APP)_mpi
 
 
 #
@@ -87,11 +87,11 @@ $(APP)_mpi_ompoffload: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPI
 # Tiled version
 #
 $(APP)_tiled: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_seq.a $(OPS_FILES_GEN) $(HEADERS)
-		$(MPICPP) $(CXXFLAGS) $(OMPFLAGS) -D$(OPS_COMPILER) -DOPS_LAZY -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_SEQ) $(OPS_LINK) $(OPS_LIB_SEQ) -o $(APP)_tiled
+		$(MPICPP) $(CXXFLAGS) $(OMPFLAGS) -DOPS_LAZY -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_SEQ) $(OPS_LINK) $(OPS_LIB_SEQ) -o $(APP)_tiled
 
 $(APP)_mpi_tiled: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_mpi.a $(OPS_FILES_GEN) \
                 $(HEADERS)
-		$(MPICPP) $(CXXFLAGS) $(OMPFLAGS) -DOPS_MPI -D$(OPS_COMPILER) -DOPS_LAZY -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI) -o $(APP)_mpi_tiled
+		$(MPICPP) $(CXXFLAGS) $(OMPFLAGS) -DOPS_MPI -DOPS_LAZY -I$(C_OPS_INC) -L$(C_OPS_LIB) $(OPS_FILES_GEN) $(TRID_LIB) -I. ./MPI_OpenMP/$(SEQ_KERNELS) $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI) -o $(APP)_mpi_tiled
 
 #
 # CUDA version
@@ -150,19 +150,19 @@ $(APP)_mpi_inline: .generated $(OPS_FILES_GEN) $(HEADERS) Makefile $(OPS_INSTALL
 					$(OPS_FILES_GEN) -I. MPI_inline/$(MAIN_SRC)_kernels_c.o MPI_inline/$(MAIN_SRC)_kernels.o $(HDF5_LIB_MPI) $(OPS_LINK) $(OPS_LIB_MPI) -o $(APP)_mpi_inline
 
 $(APP)_openacc: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_cuda.a
-	$(CC) $(OpenACCFLAGS) $(CCFLAGS) $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) $(CUDA_INC) \
+	$(CC) $(OpenACCFLAGS) $(CCFLAGS) $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) -I$(CUDA_INC) \
 	-I. OpenACC/$(MAIN_SRC)_kernels_c.c -c -o OpenACC/$(MAIN_SRC)_kernels_c.o
-	$(CXX) $(OpenACCFLAGS)  $(CXXFLAGS) $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) $(CUDA_INC) \
+	$(CXX) $(OpenACCFLAGS)  $(CXXFLAGS) $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) -I$(CUDA_INC) \
 	-I. OpenACC/$(MAIN_SRC)_kernels.cpp -c -o OpenACC/$(MAIN_SRC)_kernels.o
-	$(CXX) $(OpenACCFLAGS) $(CXXFLAGS) $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) -L$(C_OPS_LIB) $(CUDA_INC) -L$(CUDA_LIB) \
+	$(CXX) $(OpenACCFLAGS) $(CXXFLAGS) $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) -L$(C_OPS_LIB) -I$(CUDA_INC) -L$(CUDA_LIB) \
 		$(OPS_FILES_GEN) -I. OpenACC/$(MAIN_SRC)_kernels_c.o OpenACC/$(MAIN_SRC)_kernels.o -lcudart $(HDF5_LIB_SEQ) -lops_cuda -o $(APP)_openacc
 
 $(APP)_mpi_openacc: Makefile .generated $(OPS_INSTALL_PATH)/c/lib/$(OPS_COMPILER)/libops_mpi_cuda.a
-	$(MPICC) $(OpenACCFLAGS) -Minline $(CCFLAGS) -DOPS_MPI $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) $(CUDA_INC) \
+	$(MPICC) $(OpenACCFLAGS) -Minline $(CCFLAGS) -DOPS_MPI $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) -I$(CUDA_INC) \
 	-I. OpenACC/$(MAIN_SRC)_kernels_c.c -c -o OpenACC/$(MAIN_SRC)_kernels_c_mpi.o
-	$(MPICPP) $(OpenACCFLAGS)  $(CXXFLAGS) -DOPS_MPI $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) $(CUDA_INC) \
+	$(MPICPP) $(OpenACCFLAGS)  $(CXXFLAGS) -DOPS_MPI $(CUDA_ALIGNE_FLAG) -I$(C_OPS_INC) -I$(CUDA_INC) \
 	-I. OpenACC/$(MAIN_SRC)_kernels.cpp -c -o OpenACC/$(MAIN_SRC)_kernels_mpi.o
-	        $(MPICPP) $(OpenACCFLAGS) $(CUDA_ALIGNE_FLAG) $(CXXFLAGS) -DOPS_MPI -I$(C_OPS_INC) -L$(C_OPS_LIB) $(CUDA_INC) -L$(CUDA_LIB) \
+	        $(MPICPP) $(OpenACCFLAGS) $(CUDA_ALIGNE_FLAG) $(CXXFLAGS) -DOPS_MPI -I$(C_OPS_INC) -L$(C_OPS_LIB) -I$(CUDA_INC) -L$(CUDA_LIB) \
 	        $(OPS_FILES_GEN) -I. OpenACC/$(MAIN_SRC)_kernels_c_mpi.o OpenACC/$(MAIN_SRC)_kernels_mpi.o -lcudart $(HDF5_LIB_MPI) -lops_mpi_cuda -o $(APP)_mpi_openacc
 
 CL_SEQ_KERNELS = $(MAIN_SRC)_seq_kernels.cpp

--- a/makefiles/Makefile.clang
+++ b/makefiles/Makefile.clang
@@ -7,7 +7,7 @@ else
 	CCFLAGS   := -O3 -std=c99 -fPIC -DUNIX -Wall -g #-ffloat-store
 	CXXFLAGS  := -O3 -fPIC -DUNIX -Wall -g -std=c++17
 endif
-OMPFLAGS=#-fopenmp
+OMPFLAGS=-fopenmp
 OMPOFFLOADFLAGS=-fopenmp
 ifdef THREADED
 	THREADING_FLAGS ?= -fopenmp

--- a/makefiles/Makefile.cuda
+++ b/makefiles/Makefile.cuda
@@ -1,5 +1,5 @@
 NVCC  ?= $(CUDA_INSTALL_PATH)/bin/nvcc
-CUDA_INC ?= -I$(CUDA_INSTALL_PATH)/include
+CUDA_INC ?= $(CUDA_INSTALL_PATH)/include
 CUDA_LIB ?= $(CUDA_INSTALL_PATH)/lib64
 NVCCFLAGS := -Xcompiler="-fPIC"
 ifndef DEBUG

--- a/makefiles/Makefile.gnu
+++ b/makefiles/Makefile.gnu
@@ -8,11 +8,11 @@ ifdef DEBUG
 	FFLAGS += -O0 -g -ffree-form -ffree-line-length-none -J$(F_INC_MOD)
 else
 	CCFLAGS   := -O3 -std=c99 -fPIC -Wall -ffloat-store -g -ftree-vectorize -fopenmp
-	CXXFLAGS   := -O3 -fPIC -Wall -ffloat-store -g -std=c++11 #-fopenmp
+	CXXFLAGS   := -O3 -fPIC -Wall -ffloat-store -g -std=c++11
 	FFLAGS += -O3 -g -ffree-form -ffree-line-length-none -fopenmp -J$(F_INC_MOD)
 endif
 CXXLINK := -lstdc++
-OMPFLAGS := #-fopenmp
+OMPFLAGS := -fopenmp
 ifdef THREADED
 	THREADING_FLAGS ?= -fopenmp
 endif


### PR DESCRIPTION
1. -fopenmp: OMPFLAGS readded for gnu and clang, and -fopenmp removed in c_app and replaced with OMPFLAGS when needed. Side effect: dev_seq and dev_mpi app files lose -fopenmp.

2. CUDA_INC does not include -I. Removes double -I in cuda compilation. To keep openacc compile command the same added -I ro thoose command.

3. Remove unused -D$(OPS_COMPILER) flags.

4. Remove -std=c++11 from dev_seq and dev_mpi. CXXFLAGS contains this.