### PR TITLE
Fix potential segfault flagged by compiler:

### DIFF
--- a/ops/c/src/core/ops_dummy_singlenode.cpp
+++ b/ops/c/src/core/ops_dummy_singlenode.cpp
@@ -623,7 +623,7 @@ void ops_dat_set_data(ops_dat dat, int part, char *data) {
 void ops_dat_set_data_host(ops_dat dat, int part, char *data) {
   ops_execute(dat->block->instance);
 
-  int *range{new int(2 * dat->block->dims)};
+  int *range{new int[2 * dat->block->dims]};
   for (int d = 0; d < dat->block->dims; d++) {
     range[2 * d] = dat->d_m[d];
     range[2 * d + 1] = dat->size[d] - dat->d_p[d];

--- a/ops/c/src/mpi/ops_mpi_rt_support.cpp
+++ b/ops/c/src/mpi/ops_mpi_rt_support.cpp
@@ -1522,8 +1522,8 @@ void ops_dat_set_data(ops_dat dat, int part, char *data) {
   ops_execute(dat->block->instance);
   const sub_dat *sd = OPS_sub_dat_list[dat->index];
   const int space_dim{dat->block->dims};
-  int *local_range{new int(2 * space_dim)};
-  int *range{new int(2 * space_dim)};
+  int *local_range{new int[2 * space_dim]};
+  int *range{new int[2 * space_dim]};
   for (int d = 0; d < space_dim; d++) {
     range[2 * d] = sd->gbl_d_m[d];
     range[2 * d + 1] = sd->gbl_size[d] - sd->gbl_d_p[d];


### PR DESCRIPTION
Compiler warning:
> src/mpi/ops_mpi_rt_support.cpp: In function ‘void ops_dat_set_data(ops_dat, int, char*)’:
> src/mpi/ops_mpi_rt_support.cpp:1529:20: warning: array subscript 1 is outside array bounds of ‘void [4]’ [-Warray-bounds=]
>  1529 |     range[2 * d + 1] = sd->gbl_size[d] - sd->gbl_d_p[d];
>       |     ~~~~~~~~~~~~~~~^
> src/mpi/ops_mpi_rt_support.cpp:1526:35: note: at offset 4 into object of size 4 allocated by ‘operator new’
>  1526 |   int *range{new int(2 * space_dim)};
>       |

Issue:
I assume `range` and `local_range` should be an array based on the use. Allocation of `range` and `local_range` allocate a single integer on heap with value `2 * space_dim` instead of an array of length `2 * space_dim`.

```c++
  int *local_range{new int(2 * space_dim)}; // should be new int[2 * space_dim]
  int *range{new int(2 * space_dim)};       // should be new int[2 * space_dim]
  for (int d = 0; d < space_dim; d++) {
    range[2 * d] = sd->gbl_d_m[d];
    range[2 * d + 1] = sd->gbl_size[d] - sd->gbl_d_p[d];
  }
```