### PR TITLE
Automatic energy consumption measurement with RAPL/powercap

### DIFF
--- a/apps/c/CMakeLists.txt
+++ b/apps/c/CMakeLists.txt
@@ -886,9 +886,9 @@
                     endif()
                 endif()
 
-                target_link_libraries(${Name}_mpi_cuda PRIVATE ops_mpi_cuda CUDA::cudart_static -lcurand MPI::MPI_CXX
+                target_link_libraries(${Name}_mpi_cuda PRIVATE ops_mpi_cuda CUDA::cudart_static -lcurand -lnvidia-ml MPI::MPI_CXX
                                         OpenMP::OpenMP_CXX)
-                target_link_libraries(${Name}_mpi_cuda_tiled PRIVATE ops_mpi_cuda CUDA::cudart_static -lcurand MPI::MPI_CXX
+                target_link_libraries(${Name}_mpi_cuda_tiled PRIVATE ops_mpi_cuda CUDA::cudart_static -lcurand -lnvidia-ml MPI::MPI_CXX
                                         OpenMP::OpenMP_CXX)
 
                 install(TARGETS ${Name}_mpi_cuda DESTINATION ${APP_INSTALL_DIR}/${Name})

--- a/apps/c/CMakeLists.txt
+++ b/apps/c/CMakeLists.txt
@@ -712,7 +712,7 @@
                             "${TMP_SOURCE_DIR}/cuda/cuda_kernels.cu")
             target_include_directories(${Name}_cuda PRIVATE ${TMP_SOURCE_DIR})
             target_compile_options(${Name}_cuda PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--fmad=false>)
-            target_link_libraries(${Name}_cuda ops_cuda CUDA::cudart_static -lcurand OpenMP::OpenMP_CXX)
+            target_link_libraries(${Name}_cuda ops_cuda CUDA::cudart_static -lcurand -lnvidia-ml OpenMP::OpenMP_CXX)
             if(HDF5_SEQ)
                 target_link_libraries(${Name}_cuda ops_hdf5_seq hdf5::hdf5 hdf5::hdf5_hl)
             endif()

--- a/apps/c/CloverLeaf/Makefile
+++ b/apps/c/CloverLeaf/Makefile
@@ -31,5 +31,5 @@ MAIN_SRC=clover_leaf
 
 TARGETS=dev_seq dev_mpi seq tiled openmp mpi mpi_tiled mpi_openmp cuda mpi_cuda mpi_cuda_tiled hip mpi_hip mpi_hip_tiled ompoffload mpi_ompoffload mpi_ompoffload_tiled sycl mpi_sycl mpi_sycl_tiled
 
-#include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app_legacy
-include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app
+include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app_legacy
+#include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app

--- a/apps/c/CloverLeaf/clover_leaf.cpp
+++ b/apps/c/CloverLeaf/clover_leaf.cpp
@@ -172,6 +172,7 @@ int main(int argc, char **argv)
   ***************************************************************************/
   double ct0, ct1, et0, et1;
 
+  clover_grid->instance->reset_power_counters();
 #ifdef PROFILE_ITT
   __itt_resume();
 #endif

--- a/apps/c/CloverLeaf/clover_leaf.cpp
+++ b/apps/c/CloverLeaf/clover_leaf.cpp
@@ -172,6 +172,8 @@ int main(int argc, char **argv)
   ***************************************************************************/
   double ct0, ct1, et0, et1;
 
+  //We time the main computational part below, we only want energy consumption
+  // for the same region of code
   clover_grid->instance->reset_power_counters();
 #ifdef PROFILE_ITT
   __itt_resume();

--- a/apps/c/CloverLeaf_3D/Makefile
+++ b/apps/c/CloverLeaf_3D/Makefile
@@ -32,5 +32,5 @@ MAIN_SRC=clover_leaf
 #OPS_GENERATOR_VERBOSE=1
 TARGETS=dev_seq dev_mpi seq tiled openmp mpi mpi_tiled mpi_openmp cuda mpi_cuda mpi_cuda_tiled hip mpi_hip mpi_hip_tiled ompoffload mpi_ompoffload mpi_ompoffload_tiled sycl mpi_sycl mpi_sycl_tiled
 
-#include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app_legacy
-include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app
+include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app_legacy
+#include $(OPS_INSTALL_PATH)/../makefiles/Makefile.c_app

--- a/apps/c/CloverLeaf_3D/clover_leaf.cpp
+++ b/apps/c/CloverLeaf_3D/clover_leaf.cpp
@@ -175,6 +175,7 @@ int main(int argc, const char **argv) {
   **-----------------------------hydro loop---------------------------------**
   ***************************************************************************/
   double ct0, ct1, et0, et1;
+  clover_grid->instance->reset_power_counters();
 #ifdef PROFILE_ITT
   __itt_resume();
 #endif

--- a/apps/c/CloverLeaf_3D/clover_leaf.cpp
+++ b/apps/c/CloverLeaf_3D/clover_leaf.cpp
@@ -175,6 +175,9 @@ int main(int argc, const char **argv) {
   **-----------------------------hydro loop---------------------------------**
   ***************************************************************************/
   double ct0, ct1, et0, et1;
+
+  //We time the main computational part below, we only want energy consumption
+  // for the same region of code
   clover_grid->instance->reset_power_counters();
 #ifdef PROFILE_ITT
   __itt_resume();

--- a/apps/c/lowdim_test/lowdim.cpp
+++ b/apps/c/lowdim_test/lowdim.cpp
@@ -14,6 +14,18 @@
 #include "ops_seq_v2.h"
 #include "lowdim_kernels.h"
 
+
+void checkError(int error_count, const char* test_name) {
+  if (error_count > 0)
+  {
+    ops_printf("%d errors found in %s\n", error_count, test_name);
+    ops_printf("TEST FAILED\n");
+    ops_exit();
+    exit(1);
+  }
+}
+
+
 int main(int argc, char **argv) 
 {
   // Initializing OPS 
@@ -71,51 +83,349 @@ int main(int argc, char **argv)
   ops_stencil S3D_000_STRID3D_XZ = ops_decl_strided_stencil( 3, 1, s3D_000, stride3D_xz, "s2D_000_stride3D_xz");
 
 
+  ops_reduction reduct_err = ops_decl_reduction_handle(sizeof(int), "int", "reduct_err");
+
   // Init OPS partition
   ops_partition("");
 
 
-  double val = 0.0;
+  
   int range_3D[] = {0, 10, 0, 10, 0, 10};
-  ops_par_loop(set_val, "set_val", block, 3, range_3D,
-      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_WRITE),
-      ops_arg_gbl(&val, 1, "double", OPS_READ));
-
-  val = 1.0;
   int range_2D_XY[] = {0, 10, 0, 10, 0, 1};
-  ops_par_loop(set_val, "set_val", block, 3, range_2D_XY,
-      ops_arg_dat(dat2D_XY, 1, S3D_000, "double", OPS_WRITE),
-      ops_arg_gbl(&val, 1, "double", OPS_READ));
+  int range_2D_YZ[] = {9, 10, 0, 10, 0, 10};
+  int range_2D_XZ[] = {0, 10, 5, 6, 0, 10};
 
-  val = 2.0;
-  int range_2D_YZ[] = {0, 1, 0, 10, 0, 10};
-  ops_par_loop(set_val, "set_val", block, 3, range_2D_YZ,
-      ops_arg_dat(dat2D_YZ, 1, S3D_000, "double", OPS_WRITE),
-      ops_arg_gbl(&val, 1, "double", OPS_READ));
+  size[0] = 10; size[1] = 10; size[2] = 10;
+  ops_par_loop(set3D, "set3D", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_WRITE),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx());
+ 
+  ops_printf("Check OPS_MAX on 2D directions...\n");
 
-  val = 3.0;
-  int range_2D_XZ[] = {0, 10, 0, 1, 0, 10};
-  ops_par_loop(set_val, "set_val", block, 3, range_2D_XZ,
-      ops_arg_dat(dat2D_XZ, 1, S3D_000, "double", OPS_WRITE),
-      ops_arg_gbl(&val, 1, "double", OPS_READ));
+      
+  // Reduction to lower dimension
+  ops_par_loop(reduct22D_max, "reduct22D_max", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_READ),
+      ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_MAX),
+      ops_arg_dat(dat2D_XY, 1, S3D_000_STRID3D_XY, "double", OPS_MAX),
+      ops_arg_dat(dat2D_YZ, 1, S3D_000_STRID3D_YZ, "double", OPS_MAX));
 
-  val = 4.0;
-  int range_1D_X[] = {0, 10, 0, 1, 0, 1};
-  ops_par_loop(set_val, "set_val", block, 3, range_1D_X,
-      ops_arg_dat(dat1D_X, 1, S3D_000, "double", OPS_WRITE),
-      ops_arg_gbl(&val, 1, "double", OPS_READ));
 
-  val = 5.0;
-  int range_1D_Y[] = {0, 1, 0, 10, 0, 1};
-  ops_par_loop(set_val, "set_val", block, 3, range_1D_Y,
-      ops_arg_dat(dat1D_Y, 1, S3D_000, "double", OPS_WRITE),
-      ops_arg_gbl(&val, 1, "double", OPS_READ));
+  int error_count = 0;
+  ops_par_loop(check2D_XY_max, "check2D_XY_max", block, 3, range_2D_XY,
+      ops_arg_dat(dat2D_XY, 1, S3D_000_STRID3D_XY, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
 
-  val = 6.0;
-  int range_1D_Z[] = {0, 1, 0, 1, 0, 10};
-  ops_par_loop(set_val, "set_val", block, 3, range_1D_Z,
-      ops_arg_dat(dat1D_Z, 1, S3D_000, "double", OPS_WRITE),
-      ops_arg_gbl(&val, 1, "double", OPS_READ));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_XY_max");
+
+  ops_par_loop(check2D_XZ_max, "check2D_XZ_max", block, 3, range_2D_XZ,
+    ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_READ),
+    ops_arg_gbl(size, 3, "int", OPS_READ),
+    ops_arg_idx(),
+    ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_XZ_max");
+
+  
+  ops_par_loop(check2D_YZ_max, "check2D_YZ_max", block, 3, range_2D_YZ,
+    ops_arg_dat(dat2D_YZ, 1, S3D_000_STRID3D_YZ, "double", OPS_READ),
+    ops_arg_gbl(size, 3, "int", OPS_READ),
+    ops_arg_idx(),
+    ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_YZ_max");
+
+  ops_printf("OPS_MAX on 2D directions OK\n");
+
+  
+  ops_printf("Check OPS_MIN on 2D directions...\n");
+      
+  // Reduction to lower dimension
+  ops_par_loop(reduct22D_min, "reduct22D_min", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_READ),
+      ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_MIN),
+      ops_arg_dat(dat2D_XY, 1, S3D_000_STRID3D_XY, "double", OPS_MIN),
+      ops_arg_dat(dat2D_YZ, 1, S3D_000_STRID3D_YZ, "double", OPS_MIN));
+
+
+  error_count = 0;
+  ops_par_loop(check2D_XY_min, "check2D_XY_min", block, 3, range_2D_XY,
+      ops_arg_dat(dat2D_XY, 1, S3D_000_STRID3D_XY, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_XY_min");
+
+  ops_par_loop(check2D_XZ_min, "check2D_XZ_min", block, 3, range_2D_XZ,
+    ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_READ),
+    ops_arg_gbl(size, 3, "int", OPS_READ),
+    ops_arg_idx(),
+    ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_XZ_min");
+
+  
+  ops_par_loop(check2D_YZ_min, "check2D_YZ_min", block, 3, range_2D_YZ,
+    ops_arg_dat(dat2D_YZ, 1, S3D_000_STRID3D_YZ, "double", OPS_READ),
+    ops_arg_gbl(size, 3, "int", OPS_READ),
+    ops_arg_idx(),
+    ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_YZ_min");
+
+  ops_printf("OPS_MIN on 2D directions OK\n");
+
+
+  
+  ops_printf("Check OPS_INC on 2D directions...\n");
+      
+  // Reduction to lower dimension
+  ops_par_loop(reduct22D_inc, "reduct22D_inc", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_READ),
+      ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_INC),
+      ops_arg_dat(dat2D_XY, 1, S3D_000_STRID3D_XY, "double", OPS_INC),
+      ops_arg_dat(dat2D_YZ, 1, S3D_000_STRID3D_YZ, "double", OPS_INC));
+
+
+  error_count = 0;
+  ops_par_loop(check2D_XY_inc, "check2D_XY_inc", block, 3, range_2D_XY,
+      ops_arg_dat(dat2D_XY, 1, S3D_000_STRID3D_XY, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_XY_inc");
+
+  ops_par_loop(check2D_XZ_inc, "check2D_XZ_inc", block, 3, range_2D_XZ,
+    ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_READ),
+    ops_arg_gbl(size, 3, "int", OPS_READ),
+    ops_arg_idx(),
+    ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_XZ_inc");
+
+  
+  ops_par_loop(check2D_YZ_inc, "check2D_YZ_inc", block, 3, range_2D_YZ,
+    ops_arg_dat(dat2D_YZ, 1, S3D_000_STRID3D_YZ, "double", OPS_READ),
+    ops_arg_gbl(size, 3, "int", OPS_READ),
+    ops_arg_idx(),
+    ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check2D_YZ_inc");
+
+  ops_printf("OPS_INC on 2D directions OK\n");
+
+
+
+
+  int range_1D_X[] = {0, 10, 0, 1, 5, 6};
+  int range_1D_Y[] = {2, 3, 0, 10, 9, 10};
+  int range_1D_Z[] = {0, 1, 9, 10, 0, 10};
+ 
+  ops_printf("Check OPS_MAX on 1D directions...\n");
+
+  ops_par_loop(reduct21D_max, "reduct21D_max", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_READ),
+      ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_MAX),
+      ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_MAX),
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_MAX));
+
+  ops_par_loop(check1D_X_max, "check1D_X_max", block, 3, range_1D_X,
+      ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_X_max");
+  
+  
+  ops_par_loop(check1D_Y_max, "check1D_Y_max", block, 3, range_1D_Y,
+      ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_Y_max");
+  
+
+  ops_par_loop(check1D_Z_max, "check1D_Z_max", block, 3, range_1D_Z,
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_Z_max");
+
+  ops_printf("OPS_MAX on 1D directions OK\n");
+
+
+  ops_printf("Check OPS_MIN on 1D directions...\n");
+
+  ops_par_loop(reduct21D_min, "reduct21D_min", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_READ),
+      ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_MIN),
+      ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_MIN),
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_MIN));
+
+
+
+
+  ops_par_loop(check1D_X_min, "check1D_X_min", block, 3, range_1D_X,
+      ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_X_min");
+  
+  
+  ops_par_loop(check1D_Y_min, "check1D_Y_min", block, 3, range_1D_Y,
+      ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_Y_min");
+  
+
+  ops_par_loop(check1D_Z_min, "check1D_Z_min", block, 3, range_1D_Z,
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_Z_min");
+
+  ops_printf("OPS_MIN on 1D directions OK\n");
+
+
+  ops_printf("Check OPS_INC on 1D directions...\n");
+
+  ops_par_loop(reduct21D_inc, "reduct21D_inc", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_READ),
+      ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_INC),
+      ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_INC),
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_INC));
+
+
+  ops_par_loop(check1D_X_inc, "check1D_X_inc", block, 3, range_1D_X,
+      ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_X_inc");
+  
+  
+  ops_par_loop(check1D_Y_inc, "check1D_Y_inc", block, 3, range_1D_Y,
+      ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_Y_inc");
+  
+
+  ops_par_loop(check1D_Z_inc, "check1D_Z_inc", block, 3, range_1D_Z,
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  checkError(error_count, "check1D_Z_inc");
+
+  ops_printf("OPS_INC on 1D directions OK\n");
+
+
+  ops_printf("Check reading from strided dats...\n");
+
+  double val=1.0;
+  ops_par_loop(set_valXY_idx, "set_valXY_idx", block, 3, range_2D_XY,
+      ops_arg_dat(dat2D_XY, 1, S3D_000_STRID3D_XY, "double", OPS_WRITE),
+      ops_arg_gbl(&val, 1, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx());
+
+  val=100.0;
+  ops_par_loop(set_valYZ_idx, "set_valYZ_idx", block, 3, range_2D_YZ,
+      ops_arg_dat(dat2D_YZ, 1, S3D_000_STRID3D_YZ, "double", OPS_WRITE),
+      ops_arg_gbl(&val, 1, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx());
+  
+  val=10000.0;
+  ops_par_loop(set_valXZ_idx, "set_valXZ_idx", block, 3, range_2D_XZ,
+      ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_WRITE),
+      ops_arg_gbl(&val, 1, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx());
+      
+  val=0.01;
+  ops_par_loop(set_valX_idx, "set_valX_idx", block, 3, range_1D_X,
+      ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_WRITE),
+      ops_arg_gbl(&val, 1, "double", OPS_READ),
+      ops_arg_idx());
+
+  val=0.0001;
+  ops_par_loop(set_valY_idx, "set_valY_idx", block, 3, range_1D_Y,
+      ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_WRITE),
+      ops_arg_gbl(&val, 1, "double", OPS_READ),
+      ops_arg_idx());
+  
+  val=0.000001;
+  ops_par_loop(set_valZ_idx, "set_valZ_idx", block, 3, range_1D_Z,
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_WRITE),
+      ops_arg_gbl(&val, 1, "double", OPS_READ),
+      ops_arg_idx());
 
   // Now access them with strided stencils
   ops_par_loop(calc, "calc", block, 3, range_3D,
@@ -125,11 +435,36 @@ int main(int argc, char **argv)
       ops_arg_dat(dat2D_XZ, 1, S3D_000_STRID3D_XZ, "double", OPS_READ),
       ops_arg_dat(dat1D_X, 1, S3D_000_STRID3D_X, "double", OPS_READ),
       ops_arg_dat(dat1D_Y, 1, S3D_000_STRID3D_Y, "double", OPS_READ),
-      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_READ));
+      ops_arg_dat(dat1D_Z, 1, S3D_000_STRID3D_Z, "double", OPS_READ),
+      ops_arg_idx());
+
+  ops_par_loop(check_3D, "check_3D", block, 3, range_3D,
+      ops_arg_dat(dat3D, 1, S3D_000, "double", OPS_READ),
+      ops_arg_gbl(size, 3, "int", OPS_READ),
+      ops_arg_idx(),
+      ops_arg_reduce(reduct_err, 1, "int", OPS_INC));
+
+  ops_reduction_result(reduct_err, &error_count);
+
+  char name0[80];
+  sprintf(name0, "output.h5");
+  ops_fetch_block_hdf5_file(block, name0);
+  ops_fetch_dat_hdf5_file(dat3D, name0);
+
+  checkError(error_count, "check_3D");
+      
+
+  ops_printf("Calc done\n");
+  
+  ops_fetch_dat_hdf5_file(dat2D_XZ, name0);
+  ops_fetch_dat_hdf5_file(dat2D_XY, name0);
+  ops_fetch_dat_hdf5_file(dat2D_YZ, name0);
+  ops_fetch_dat_hdf5_file(dat1D_X, name0);
+  ops_fetch_dat_hdf5_file(dat1D_Y, name0);
+  ops_fetch_dat_hdf5_file(dat1D_Z, name0);
 
 
-  ops_dump_to_hdf5("output.h5");
-  ops_printf("PASSED");
+  ops_printf("All checks PASSED\n");
 
   ops_exit();
   return 0;

--- a/apps/fortran/CMakeLists.txt
+++ b/apps/fortran/CMakeLists.txt
@@ -793,7 +793,7 @@
                     if(HDF5_SEQ)
                         target_link_libraries(${Name}_cuda PRIVATE ops_for_hdf5_seq hdf5::hdf5 hdf5::hdf5_hl)
                     endif()
-                    target_link_libraries(${Name}_cuda PRIVATE ops_for_cuda "-cudalib=curand -c++libs -lstdc++ -lcudart")
+                    target_link_libraries(${Name}_cuda PRIVATE ops_for_cuda "-cudalib=curand -lnvidia-ml -c++libs -lstdc++ -lcudart")
                     install(TARGETS ${Name}_cuda     DESTINATION ${APP_INSTALL_DIR}/${Name})
 
                     if((OPS_TEST)

--- a/apps/fortran/CMakeLists.txt
+++ b/apps/fortran/CMakeLists.txt
@@ -835,7 +835,7 @@
                              target_link_libraries(${Name}_mpi_cuda PRIVATE ops_for_hdf5_mpi hdf5::hdf5 hdf5::hdf5_hl
                                                                 MPI::MPI_Fortran)
                         endif()
-                        target_link_libraries(${Name}_mpi_cuda PRIVATE ops_for_mpi_cuda MPI::MPI_Fortran "${MPI_LINK}" "-cudalib=curand -c++libs -lstdc++ -lcudart")
+                        target_link_libraries(${Name}_mpi_cuda PRIVATE ops_for_mpi_cuda MPI::MPI_Fortran "${MPI_LINK}" "-cudalib=curand -c++libs -lstdc++ -lcudart -lnvidia-ml")
                         install(TARGETS ${Name}_mpi_cuda     DESTINATION ${APP_INSTALL_DIR}/${Name})
 
                         if((OPS_TEST)
@@ -879,7 +879,7 @@
                              target_link_libraries(${Name}_mpi_cuda_tiled PRIVATE ops_for_hdf5_mpi hdf5::hdf5 hdf5::hdf5_hl
                                                                 MPI::MPI_Fortran)
                         endif()
-                        target_link_libraries(${Name}_mpi_cuda_tiled PRIVATE ops_for_mpi_cuda MPI::MPI_Fortran "${MPI_LINK}" "-cudalib=curand -c++libs -lstdc++ -lcudart")
+                        target_link_libraries(${Name}_mpi_cuda_tiled PRIVATE ops_for_mpi_cuda MPI::MPI_Fortran "${MPI_LINK}" "-cudalib=curand -c++libs -lstdc++ -lcudart -lnvidia-ml")
                         install(TARGETS ${Name}_mpi_cuda_tiled     DESTINATION ${APP_INSTALL_DIR}/${Name})
 
                         if((OPS_TEST)

--- a/makefiles/Makefile.cuda
+++ b/makefiles/Makefile.cuda
@@ -2,6 +2,8 @@ NVCC  ?= $(CUDA_INSTALL_PATH)/bin/nvcc
 CUDA_INC ?= $(CUDA_INSTALL_PATH)/include
 CUDA_LIB ?= $(CUDA_INSTALL_PATH)/lib64
 
+CUDA_LIB += -lnvidia-ml
+
 ifneq ($(CUDA_MATH_LIBS),)
 	CUDA_LIB += -L$(CUDA_MATH_LIBS)
 endif

--- a/makefiles/Makefile.gnu
+++ b/makefiles/Makefile.gnu
@@ -21,4 +21,3 @@ FMODS_F2C_CUDA    := -J$(F_INC_MOD)/f2c_cuda
 
 CXXLINK := -lstdc++
 FTNLINK := -lgfortran
-#MPI_LINK = -lmpi_cxx

--- a/makefiles/Makefile.hip
+++ b/makefiles/Makefile.hip
@@ -8,6 +8,8 @@ HIP_INC ?= $(HIP_INSTALL_PATH)/include -I$(HIP_INSTALL_PATH)/../include
 HIP_LIB ?= $(HIP_INSTALL_PATH)/lib
 MPI_HIP_LINK ?= -L$(MPI_LIB) -lmpi
 
+HIP_LIB += -lrocm_smi64
+
 #HIP_LINK ?= $(shell mpicxx --showme:compile) -L$(HIP_INSTALL_PATH)/lib -L$(HIP_INSTALL_PATH)/lib64 -L$(HIP_INSTALL_PATH)/hsa/lib64 -L$(HIP_INSTALL_PATH)/hsa/lib -L$(HIP_INSTALL_PATH)/hcc/lib -lhc_am -lmcwamp -lhip_hcc -lhsa-runtime64 -lamd_comgr -lhsakmt $(shell mpicxx --showme:link)
 
 HIPMPICPP ?= $(HIPCC)

--- a/makefiles/Makefile.intel
+++ b/makefiles/Makefile.intel
@@ -1,5 +1,5 @@
-CC    := icc
-CXX   := icpc
+CC    := icx
+CXX   := icpx
 FC    := ifort
 ifdef DEBUG
 	CCFLAGS   := -O0 -xHost -g -std=c99

--- a/makefiles/Makefile.intel
+++ b/makefiles/Makefile.intel
@@ -6,7 +6,10 @@ ifdef DEBUG
 	CXXFLAGS   := -O0 -g -xHost -DOPS_DEBUG -std=c++17
 else
 	CCFLAGS   := -O3 -g -xHost -std=c99 -qopenmp -qopt-report #enmp #vec-report -xAVX
-	CXXFLAGS   := -O3 -g -xHost -qopenmp -qopt-report -std=c++17 -qopt-zmm-usage=high #-qopenmp #vec-report -xAVX
+	CXXFLAGS   := -O3 -g -xHost -qopenmp -qopt-report -std=c++17 #-qopt-zmm-usage=high #-qopenmp #vec-report -xAVX
+	ifdef TEST_ZMM
+		CXXFLAGS += -qopt-zmm-usage=high
+	endif
 endif
 ifdef IEEE
 	CCFLAGS += -fp-model strict -fp-model source -prec-div -prec-sqrt

--- a/makefiles/Makefile.intel
+++ b/makefiles/Makefile.intel
@@ -3,10 +3,10 @@ CXX   := icpx
 FC    := ifort
 ifdef DEBUG
 	CCFLAGS   := -O0 -xHost -g -std=c99
-	CXXFLAGS   := -O0 -g -xHost -DOPS_DEBUG -std=c++11
+	CXXFLAGS   := -O0 -g -xHost -DOPS_DEBUG -std=c++17
 else
 	CCFLAGS   := -O3 -g -xHost -std=c99 -qopenmp -qopt-report #enmp #vec-report -xAVX
-	CXXFLAGS   := -O3 -g -xHost -qopenmp -qopt-report -std=c++11 -qopt-zmm-usage=high #-qopenmp #vec-report -xAVX
+	CXXFLAGS   := -O3 -g -xHost -qopenmp -qopt-report -std=c++17 -qopt-zmm-usage=high #-qopenmp #vec-report -xAVX
 endif
 ifdef IEEE
 	CCFLAGS += -fp-model strict -fp-model source -prec-div -prec-sqrt
@@ -33,3 +33,7 @@ FMODS_F2C_CUDA    := -module $(F_INC_MOD)/f2c_cuda
 
 CXXLINK := -lstdc++
 FTNLINK := -lifcore -lifport
+
+SYCLCXX=icpx
+SYCLMPICXX=mpicxx
+SYCL_FLAGS=-fsycl -fsycl-targets=spir64_x86_64 -Xs "-march=avx512" -D__INTEL_SYCL__

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -328,7 +328,7 @@ class OPS_instance {
 	
 	//Tiling
 	int ops_enable_tiling;
-	int ops_cache_size;
+	double ops_cache_size;
 	int ops_tiling_mpidepth;
 	double ops_tiled_halo_exchange_time;
 	OPS_instance_tiling *tiling_instance;

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -237,6 +237,13 @@ class OPS_instance {
       decl_const(name, dim, type, data);
     }
 
+
+/**
+ * This routine resets OPS's internal power counters.
+ * This is useful for measuring the power consumption of a specific section of
+ * code, usually after partitioning.
+ */
+	void reset_power_counters();
 /**
  * This routine prints out various useful bits of diagnostic info about sets,
  * mappings and datasets.
@@ -315,6 +322,9 @@ class OPS_instance {
 	int OPS_kern_max, OPS_kern_curr;
 	ops_kernel *OPS_kernels;
 	double ops_user_halo_exchanges_time;
+	long long *ops_energy_counters;
+	char **ops_energy_paths;
+	int ops_energy_paths_count;
 	
 	//Tiling
 	int ops_enable_tiling;

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -325,6 +325,9 @@ class OPS_instance {
 	long long *ops_energy_counters;
 	char **ops_energy_paths;
 	int ops_energy_paths_count;
+  long long ops_message_count;
+  long long ops_message_size;
+  double ops_reduction_time;
 	
 	//Tiling
 	int ops_enable_tiling;

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -381,6 +381,7 @@ class OPS_instance {
 	int OPS_block_size_x;
 	int OPS_block_size_y;
 	int OPS_block_size_z;
+	int OPS_device_id;
 	char *OPS_consts_h, *OPS_consts_d, *OPS_reduct_h, *OPS_reduct_d;
 	int OPS_consts_bytes, OPS_reduct_bytes;
 	int OPS_cl_device;

--- a/ops/c/include/ops_instance.h
+++ b/ops/c/include/ops_instance.h
@@ -244,6 +244,26 @@ class OPS_instance {
  * code, usually after partitioning.
  */
 	void reset_power_counters();
+
+/**
+ * Reset GPU power measurement counters.
+ * This initializes GPU power measurement and resets accumulated energy.
+ */
+	void reset_gpu_power_counters();
+
+/**
+ * Sample current GPU power and update energy accumulation.
+ * This should be called periodically during computation to maintain
+ * accurate energy measurements.
+ */
+	void sample_gpu_power();
+
+/**
+ * Get the total GPU energy consumed since last reset.
+ * @return Total GPU energy consumed in Joules
+ */
+	double get_gpu_energy_consumed();
+
 /**
  * This routine prints out various useful bits of diagnostic info about sets,
  * mappings and datasets.
@@ -328,6 +348,15 @@ class OPS_instance {
   long long ops_message_count;
   long long ops_message_size;
   double ops_reduction_time;
+  
+  // GPU power measurement
+  double ops_gpu_energy_consumed;      // Total GPU energy consumed in Joules
+  double ops_gpu_power_measurement_start_time;  // Time when power measurement started
+  double ops_gpu_last_power_sample_time;       // Time of last power sample
+  unsigned int ops_gpu_power_watts;           // Last measured power in Watts
+  int ops_gpu_power_measurement_active;       // Flag indicating if GPU power measurement is active
+  int ops_gpu_measurement_counter;            // Counter for GPU power measurement
+  int ops_gpu_measurement_frequency;          // Frequency of GPU power measurement
 	
 	//Tiling
 	int ops_enable_tiling;

--- a/ops/c/include/ops_internal2.h
+++ b/ops/c/include/ops_internal2.h
@@ -351,6 +351,7 @@ ops_reduction _ops_decl_reduction_handle(OPS_instance *instance, int size, const
                                         const char *name);
 void ops_free_dat_core(ops_dat dat);
 void _ops_free_dat(ops_dat dat);
+void _ops_reset_power_counters(OPS_instance *instance);
 void _ops_diagnostic_output(OPS_instance *instance);
 void _ops_timing_output(OPS_instance *instance,std::ostream &stream);
 

--- a/ops/c/include/ops_lib_core.h
+++ b/ops/c/include/ops_lib_core.h
@@ -1375,6 +1375,36 @@ void ops_fill_random_uniform(ops_dat dat);
 void ops_fill_random_normal(ops_dat dat);
 void ops_randomgen_exit();
 
+/*
+ * GPU Power Measurement Support
+ */
+
+// Global define to control NVML availability
+#ifndef OPS_ENABLE_NVML
+#define OPS_ENABLE_NVML 1  // Enable by default, disable if NVML not available
+#endif
+
+// Global define to control ROCm SMI availability
+#ifndef OPS_ENABLE_ROCM_SMI
+#define OPS_ENABLE_ROCM_SMI 1  // Enable by default, disable if ROCm SMI not available
+#endif
+
+// Backend-specific GPU power measurement functions
+// These are implemented in each backend (CUDA, HIP, etc.)
+void _ops_init_gpu_power_measurement(OPS_instance *instance);
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts);
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance);
+
+// GPU power measurement implementation functions
+void _ops_reset_gpu_power_counters(OPS_instance *instance);
+void _ops_sample_gpu_power(OPS_instance *instance);
+double _ops_get_gpu_energy_consumed(OPS_instance *instance);
+
+// Public GPU power measurement APIs
+void ops_reset_gpu_power_counters();
+void ops_sample_gpu_power();
+double ops_get_gpu_energy_consumed();
+
 
 /**
  * This class is an accessor to data stored in ops_dats. It is

--- a/ops/c/src/core/ops_instance.cpp
+++ b/ops/c/src/core/ops_instance.cpp
@@ -143,6 +143,11 @@ void OPS_instance::init_globals() {
 		}
     }
 
+
+
+  ops_message_count = 0;
+  ops_message_size = 0;
+  ops_reduction_time = 0.0;
 	
 	//Tiling
 	ops_enable_tiling = 0;

--- a/ops/c/src/core/ops_instance.cpp
+++ b/ops/c/src/core/ops_instance.cpp
@@ -1,6 +1,7 @@
 #define OPS_CPP_API
 #define OPS_INTERNAL_API
 #include <ops_lib_core.h>
+#include <unistd.h>
 
 #include <atomic>
 
@@ -80,6 +81,53 @@ void OPS_instance::init_globals() {
 	OPS_kern_max=0; OPS_kern_curr=0;
 	OPS_kernels=NULL;
 	ops_user_halo_exchanges_time = 0.0;
+
+	char default_paths[128];
+	strcpy(&default_paths[0],"/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0/energy_uj;/sys/devices/virtual/powercap/intel-rapl/intel-rapl:1/energy_uj");
+	char* env_paths = getenv("RAPL_PATH");
+	if (!env_paths) {
+		env_paths = default_paths;
+	}
+	ops_energy_paths_count = 0;
+    if (env_paths) {
+		// Count the number of paths
+		int num_paths = 0;
+		char* path = strtok(env_paths, ";");
+		while (path != NULL) {
+			num_paths++;
+			path = strtok(NULL, ";");
+		}
+
+		// Read the paths and initial energies
+		ops_energy_paths_count = num_paths;
+		ops_energy_paths = (char**)ops_malloc(sizeof(char*)*num_paths);
+		ops_energy_counters = (long long*)ops_malloc(sizeof(long long)*num_paths);
+
+		num_paths = 0;
+		path = strtok(env_paths, ";");
+		while (path != NULL) {
+			ops_energy_paths[num_paths] = strdup(path); // Duplicate the string for safekeeping
+			//check if path exists
+			if (access(path, R_OK) == -1) {
+				if (env_paths != default_paths)
+					ops_printf("Error: RAPL path %s does not exist or does not have the right permissions. Skipping.\n", path);
+				ops_energy_paths[num_paths] = NULL;
+			} else {
+				// Read initial energy
+				FILE* file = fopen(path, "r");
+				if (file == NULL) {
+					if (env_paths != default_paths)
+						ops_printf("Error: Could not open RAPL path %s. Skipping.\n", path);
+				} else {
+					fscanf(file, "%lld", &ops_energy_counters[num_paths]);
+					fclose(file);
+				}
+			}
+			num_paths++;
+			path = strtok(NULL, ";");
+		}
+    }
+
 	
 	//Tiling
 	ops_enable_tiling = 0;
@@ -167,6 +215,10 @@ ops_halo OPS_instance::decl_halo(ops_dat from, ops_dat to, int *iter_size, int *
 }
 ops_halo_group OPS_instance::decl_halo_group(int nhalos, ops_halo *halos) {
   return _ops_decl_halo_group(this, nhalos, halos);
+}
+
+void OPS_instance::reset_power_counters() {
+  _ops_reset_power_counters(this);
 }
 
 void OPS_instance::diagnostic_output() {

--- a/ops/c/src/core/ops_instance.cpp
+++ b/ops/c/src/core/ops_instance.cpp
@@ -148,6 +148,15 @@ void OPS_instance::init_globals() {
   ops_message_count = 0;
   ops_message_size = 0;
   ops_reduction_time = 0.0;
+  
+  // Initialize GPU power measurement
+  ops_gpu_energy_consumed = 0.0;
+  ops_gpu_power_measurement_start_time = 0.0;
+  ops_gpu_last_power_sample_time = 0.0;
+  ops_gpu_power_watts = 0;
+  ops_gpu_power_measurement_active = 0;
+  ops_gpu_measurement_counter = 0;
+  ops_gpu_measurement_frequency = 10;
 	
 	//Tiling
 	ops_enable_tiling = 0;
@@ -239,6 +248,18 @@ ops_halo_group OPS_instance::decl_halo_group(int nhalos, ops_halo *halos) {
 
 void OPS_instance::reset_power_counters() {
   _ops_reset_power_counters(this);
+}
+
+void OPS_instance::reset_gpu_power_counters() {
+  _ops_reset_gpu_power_counters(this);
+}
+
+void OPS_instance::sample_gpu_power() {
+  _ops_sample_gpu_power(this);
+}
+
+double OPS_instance::get_gpu_energy_consumed() {
+  return _ops_get_gpu_energy_consumed(this);
 }
 
 void OPS_instance::diagnostic_output() {

--- a/ops/c/src/core/ops_instance.cpp
+++ b/ops/c/src/core/ops_instance.cpp
@@ -179,6 +179,7 @@ void OPS_instance::init_globals() {
 	OPS_block_size_x = 32;
 	OPS_block_size_y = 4;
 	OPS_block_size_z = 1;
+	OPS_device_id = -1; // -1 means auto-select device
 	OPS_consts_h=NULL; OPS_consts_d=NULL; OPS_reduct_h=NULL; OPS_reduct_d=NULL;
 	OPS_consts_bytes = 0; OPS_reduct_bytes = 0;
 	OPS_cl_device=0;

--- a/ops/c/src/core/ops_lib_core.cpp
+++ b/ops/c/src/core/ops_lib_core.cpp
@@ -132,7 +132,7 @@ void _ops_set_args(OPS_instance *instance, const char *argv) {
   pch = strstr(argv, "OPS_CACHE_SIZE=");
   if (pch != NULL) {
     snprintf(temp, 64, "%s", pch);
-    instance->ops_cache_size = atoi(temp + 15);
+    instance->ops_cache_size = atof(temp + 15);
     if (instance->is_root()) instance->ostream() << "\n Cache size per process = " << instance->ops_cache_size << '\n';
   }
   pch = strstr(argv, "OPS_REALLOC=");

--- a/ops/c/src/core/ops_lib_core.cpp
+++ b/ops/c/src/core/ops_lib_core.cpp
@@ -1450,6 +1450,26 @@ void _ops_timing_output(OPS_instance *instance, std::ostream &stream) {
       ops_fprintf2(stream, "Total user halo exchange time: %g\n", moments_time[0]);
     }
 
+    moments_time[0] = 0.0;
+    ops_compute_moment(instance->ops_reduction_time, &moments_time[0], &moments_time[1]);
+    if (moments_time[0] > 0.0) {
+      ops_fprintf2(stream, "Total reduction time: %g\n", moments_time[0]);
+    }
+
+    moments_time[0] = 0.0;
+    double msg_count = instance->ops_message_count;
+    ops_compute_moment(msg_count, &moments_time[0], &moments_time[1]);
+    if (moments_time[0] > 0.0) {
+      ops_fprintf2(stream, "Average number of MPI messages per process: %g\n", moments_time[0]);
+    }
+
+    moments_time[0] = 0.0;
+    double msg_size = instance->ops_message_size;
+    ops_compute_moment(msg_size, &moments_time[0], &moments_time[1]);
+    if (moments_time[0] > 0.0) {
+      ops_fprintf2(stream, "Average volume of MPI communications per process: %g MB\n", moments_time[0]/1e6);
+    }
+
     long long aggregate_energy = 0;
     long long aggregate_energy_dram = 0;
     long long max_energy = 262143328850LL;

--- a/ops/c/src/core/ops_lib_core.cpp
+++ b/ops/c/src/core/ops_lib_core.cpp
@@ -201,6 +201,13 @@ void _ops_set_args(OPS_instance *instance, const char *argv) {
     if (instance->is_root()) instance->ostream() << "\n Forced decomposition in z direction = " << counts << '\n';
   }
 
+  pch = strstr(argv, "OPS_GPU_MEASUREMENT_FREQUENCY=");
+  if (pch != NULL) {
+    snprintf(temp, 64, "%s", pch);
+    instance->ops_gpu_measurement_frequency = atoi(temp + 30);
+    if (instance->is_root()) instance->ostream() << "\n GPU power measurement frequency = " << instance->ops_gpu_measurement_frequency << '\n';
+  }
+
   if (strstr(argv, "OPS_CHECKPOINT_INMEMORY") != NULL) {
     instance->ops_checkpoint_inmemory = 1;
     if (instance->is_root()) instance->ostream() << "\n OPS Checkpointing in memory\n";
@@ -263,6 +270,12 @@ void ops_init_core(OPS_instance *instance, const int argc, const char *const arg
 void ops_exit_core(OPS_instance *instance) {
   ops_checkpointing_exit(instance);
   ops_exit_lazy(instance);
+  
+  // Finalize GPU power measurement
+  if (instance->ops_gpu_power_measurement_active) {
+    _ops_finalize_gpu_power_measurement(instance);
+  }
+  
   ops_dat_entry *item = TAILQ_FIRST(&instance->OPS_dat_list);
 
   /*free doubly linked list holding the ops_dats */
@@ -1120,8 +1133,55 @@ void _ops_reset_power_counters(OPS_instance *instance) {
 				}
     }
   }
+  
+  // Reset GPU power counters as well
+  _ops_reset_gpu_power_counters(instance);
 }
 
+void _ops_reset_gpu_power_counters(OPS_instance *instance) {
+  instance->ops_gpu_energy_consumed = 0.0;
+  instance->ops_gpu_power_measurement_active = 0;
+  instance->ops_gpu_power_watts = 0;
+  instance->ops_gpu_measurement_counter = 0;
+  
+  // Get current time and initialize timing
+  double current_time;
+  ops_timers_core(&current_time, &current_time);
+  instance->ops_gpu_power_measurement_start_time = current_time;
+  instance->ops_gpu_last_power_sample_time = current_time;
+  
+  // Initialize GPU power measurement (calls backend-specific implementation)
+  if (!instance->ops_gpu_power_measurement_active) {
+    _ops_init_gpu_power_measurement(instance);
+    instance->ops_gpu_power_measurement_active = 1;
+  }
+}
+
+void _ops_sample_gpu_power(OPS_instance *instance) {
+  if (!instance->ops_gpu_power_measurement_active) return;
+  
+  double current_time;
+  ops_timers_core(&current_time, &current_time);
+  
+  // Get current GPU power (calls backend-specific implementation)
+  unsigned int current_power_watts = 0;
+  _ops_get_gpu_power(instance, &current_power_watts);
+  
+  // Calculate energy consumed since last sample (P * dt)
+  if (instance->ops_gpu_last_power_sample_time > 0) {
+    double time_delta = current_time - instance->ops_gpu_last_power_sample_time;
+    double energy_delta = instance->ops_gpu_power_watts * time_delta; // Watts * seconds = Joules
+    instance->ops_gpu_energy_consumed += energy_delta;
+  }
+  
+  // Update for next sample
+  instance->ops_gpu_power_watts = current_power_watts;
+  instance->ops_gpu_last_power_sample_time = current_time;
+}
+
+double _ops_get_gpu_energy_consumed(OPS_instance *instance) {
+  return instance->ops_gpu_energy_consumed;
+}
 
 void _ops_diagnostic_output(OPS_instance *instance) {
   if (instance->OPS_diags > 2) {
@@ -1519,7 +1579,14 @@ void _ops_timing_output(OPS_instance *instance, std::ostream &stream) {
       moments_time[0] = 0.0;
       double aggregate_energy_dram_d = (double)aggregate_energy_dram/1000000.0;
       ops_compute_moment(aggregate_energy_dram_d, &moments_time[0], &moments_time[1]);
-      ops_fprintf2(stream, "Total CPU energy consumed (RAPL): %g J, of which DRAM energy: %g\n", avg_energy, moments_time[0]);
+      ops_fprintf2(stream, "Total CPU energy consumed (RAPL): %g J, of which DRAM energy: %g J\n", avg_energy, moments_time[0]);
+    }
+
+    // GPU energy reporting
+    if (instance->ops_gpu_energy_consumed > 0.0) {
+      moments_time[0] = 0.0;
+      ops_compute_moment(instance->ops_gpu_energy_consumed, &moments_time[0], &moments_time[1]);
+      ops_fprintf2(stream, "Total GPU energy consumed: %g J\n", moments_time[0]);
     }
 
     // printf("Times: %g %g %g\n",ops_gather_time, ops_sendrecv_time,
@@ -1582,6 +1649,10 @@ void ops_timing_realloc(OPS_instance *instance, int kernel, const char *name) {
     instance->OPS_kernels[kernel].name = (char *)ops_malloc((strlen(name) + 1) * sizeof(char));
     strcpy_s(instance->OPS_kernels[kernel].name, strlen(name)+1, name);
     instance->OPS_kernels[kernel].count = 0;
+  }
+
+  if (instance->ops_gpu_power_measurement_active && instance->ops_gpu_measurement_counter++ % instance->ops_gpu_measurement_frequency == 0) {
+    _ops_sample_gpu_power(instance);
   }
 }
 
@@ -2470,3 +2541,21 @@ void _ops_free_dat(ops_dat dat) {
 extern "C" int getOPS_block_size_x() { return OPS_instance::getOPSInstance()->OPS_block_size_x; }
 extern "C" int getOPS_block_size_y() { return OPS_instance::getOPSInstance()->OPS_block_size_y; }
 extern "C" int getOPS_block_size_z() { return OPS_instance::getOPSInstance()->OPS_block_size_z; }
+
+/*
+ * GPU Power Measurement Public APIs
+ * (Backend-specific implementations are in their respective files)
+ */
+
+// Public GPU power measurement APIs that delegate to instance methods
+void ops_reset_gpu_power_counters() {
+    OPS_instance::getOPSInstance()->reset_gpu_power_counters();
+}
+
+void ops_sample_gpu_power() {
+    OPS_instance::getOPSInstance()->sample_gpu_power();
+}
+
+double ops_get_gpu_energy_consumed() {
+    return OPS_instance::getOPSInstance()->get_gpu_energy_consumed();
+}

--- a/ops/c/src/core/ops_lib_core.cpp
+++ b/ops/c/src/core/ops_lib_core.cpp
@@ -208,6 +208,13 @@ void _ops_set_args(OPS_instance *instance, const char *argv) {
     if (instance->is_root()) instance->ostream() << "\n GPU power measurement frequency = " << instance->ops_gpu_measurement_frequency << '\n';
   }
 
+  pch = strstr(argv, "OPS_DEVICE=");
+  if (pch != NULL) {
+    snprintf(temp, 64, "%s", pch);
+    instance->OPS_device_id = atoi(temp + 11);
+    if (instance->is_root()) instance->ostream() << "\n OPS device ID = " << instance->OPS_device_id << '\n';
+  }
+
   if (strstr(argv, "OPS_CHECKPOINT_INMEMORY") != NULL) {
     instance->ops_checkpoint_inmemory = 1;
     if (instance->is_root()) instance->ostream() << "\n OPS Checkpointing in memory\n";

--- a/ops/c/src/core/ops_lib_core.cpp
+++ b/ops/c/src/core/ops_lib_core.cpp
@@ -1451,6 +1451,7 @@ void _ops_timing_output(OPS_instance *instance, std::ostream &stream) {
     }
 
     long long aggregate_energy = 0;
+    long long aggregate_energy_dram = 0;
     long long max_energy = 262143328850LL;
     for (int i = 0; i < instance->ops_energy_paths_count; i++) {
       if (instance->ops_energy_paths[i] != NULL) {
@@ -1474,10 +1475,18 @@ void _ops_timing_output(OPS_instance *instance, std::ostream &stream) {
                 fscanf(max_energy_file, "%lld", &max_energy);
                 fclose(max_energy_file);
               }
-              aggregate_energy += (max_energy - instance->ops_energy_counters[i] + energy);
-            } else
-                  aggregate_energy += (energy - instance->ops_energy_counters[i]);
-                fclose(file);
+              if (i < instance->ops_energy_paths_count/2)
+                aggregate_energy += (max_energy - instance->ops_energy_counters[i] + energy);
+              else 
+                aggregate_energy_dram += (max_energy - instance->ops_energy_counters[i] + energy);
+            } else {
+              if (i < instance->ops_energy_paths_count/2)
+                aggregate_energy += (energy - instance->ops_energy_counters[i]);
+              else
+                aggregate_energy_dram += (energy - instance->ops_energy_counters[i]);
+            }
+            //ops_printf("starting value %lld, ending value %lld for %s\n", instance->ops_energy_counters[i], energy, instance->ops_energy_paths[i]);
+            fclose(file);
                 
           }
       }
@@ -1486,7 +1495,11 @@ void _ops_timing_output(OPS_instance *instance, std::ostream &stream) {
       moments_time[0] = 0.0;
       double aggregate_energy_d = (double)aggregate_energy/1000000.0;
       ops_compute_moment(aggregate_energy_d, &moments_time[0], &moments_time[1]);
-      ops_fprintf2(stream, "Total CPU energy consumed (REPL): %g J\n", moments_time[0]);
+      double avg_energy = moments_time[0];
+      moments_time[0] = 0.0;
+      double aggregate_energy_dram_d = (double)aggregate_energy_dram/1000000.0;
+      ops_compute_moment(aggregate_energy_dram_d, &moments_time[0], &moments_time[1]);
+      ops_fprintf2(stream, "Total CPU energy consumed (RAPL): %g J, of which DRAM energy: %g\n", avg_energy, moments_time[0]);
     }
 
     // printf("Times: %g %g %g\n",ops_gather_time, ops_sendrecv_time,
@@ -1895,24 +1908,24 @@ extern "C" ops_halo_group ops_decl_halo_group_elem(int nhalos, ops_halo *halos,
 
 
 void *ops_malloc(size_t size) {
-  void *ptr = NULL;
-  if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, size) ) {
-      OPSException ex(OPS_INTERNAL_ERROR);
-      ex << "Error, posix_memalign() returned an error.";
-      throw ex;
-  }
+  void *ptr = _mm_malloc(size, OPS_ALIGNMENT);
+  // if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, size) ) {
+  //     OPSException ex(OPS_INTERNAL_ERROR);
+  //     ex << "Error, posix_memalign() returned an error.";
+  //     throw ex;
+  // }
   return ptr;
 }
 
 void *ops_calloc(size_t num, size_t size) {
 //#ifdef __INTEL_COMPILER
-  // void * ptr = _mm_malloc(num*size, OPS_ALIGNMENT);
-  void *ptr=NULL;
-  if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, num*size) ) {
-      OPSException ex(OPS_INTERNAL_ERROR);
-      ex << "Error, posix_memalign() returned an error.";
-      throw ex;
-  }
+  void * ptr = _mm_malloc(num*size, OPS_ALIGNMENT);
+  // void *ptr=NULL;
+  // if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, num*size) ) {
+  //     OPSException ex(OPS_INTERNAL_ERROR);
+  //     ex << "Error, posix_memalign() returned an error.";
+  //     throw ex;
+  // }
   memset(ptr, 0, num * size);
   return ptr;
 //#else
@@ -1929,13 +1942,13 @@ void *ops_realloc(void *ptr, size_t size) {
 #endif
   static_assert(sizeof(size_t) == sizeof(void*), "size_t is not big enough to hold pointer address");
   if (((size_t)newptr & (OPS_ALIGNMENT - 1)) != 0) {
-    void *newptr2=NULL;
-    if( posix_memalign((void**)&(newptr2), OPS_ALIGNMENT, size) ) {
-        OPSException ex(OPS_INTERNAL_ERROR);
-        ex << "Error, posix_memalign() returned an error.";
-        throw ex;
-    }
-    // void *newptr2 = _mm_malloc(size, OPS_ALIGNMENT);
+    // void *newptr2=NULL;
+    // if( posix_memalign((void**)&(newptr2), OPS_ALIGNMENT, size) ) {
+    //     OPSException ex(OPS_INTERNAL_ERROR);
+    //     ex << "Error, posix_memalign() returned an error.";
+    //     throw ex;
+    // }
+    void *newptr2 = _mm_malloc(size, OPS_ALIGNMENT);
     memcpy(newptr2, newptr, size);
     ops_free(newptr);
     return newptr2;
@@ -1951,7 +1964,7 @@ void ops_free(void *ptr) {
 #if defined (_WIN32) || defined(WIN32)
   _aligned_free(ptr);
 #else
-  free(ptr);
+  _mm_free(ptr);
 #endif
 }
 

--- a/ops/c/src/core/ops_lib_core.cpp
+++ b/ops/c/src/core/ops_lib_core.cpp
@@ -1928,24 +1928,24 @@ extern "C" ops_halo_group ops_decl_halo_group_elem(int nhalos, ops_halo *halos,
 
 
 void *ops_malloc(size_t size) {
-  void *ptr = _mm_malloc(size, OPS_ALIGNMENT);
-  // if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, size) ) {
-  //     OPSException ex(OPS_INTERNAL_ERROR);
-  //     ex << "Error, posix_memalign() returned an error.";
-  //     throw ex;
-  // }
+  void *ptr=NULL;// = _mm_malloc(size, OPS_ALIGNMENT);
+  if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, size) ) {
+      OPSException ex(OPS_INTERNAL_ERROR);
+      ex << "Error, posix_memalign() returned an error.";
+      throw ex;
+  }
   return ptr;
 }
 
 void *ops_calloc(size_t num, size_t size) {
 //#ifdef __INTEL_COMPILER
-  void * ptr = _mm_malloc(num*size, OPS_ALIGNMENT);
-  // void *ptr=NULL;
-  // if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, num*size) ) {
-  //     OPSException ex(OPS_INTERNAL_ERROR);
-  //     ex << "Error, posix_memalign() returned an error.";
-  //     throw ex;
-  // }
+  //void * ptr = _mm_malloc(num*size, OPS_ALIGNMENT);
+  void *ptr=NULL;
+  if( posix_memalign((void**)&(ptr), OPS_ALIGNMENT, num*size) ) {
+      OPSException ex(OPS_INTERNAL_ERROR);
+      ex << "Error, posix_memalign() returned an error.";
+      throw ex;
+  }
   memset(ptr, 0, num * size);
   return ptr;
 //#else
@@ -1962,13 +1962,13 @@ void *ops_realloc(void *ptr, size_t size) {
 #endif
   static_assert(sizeof(size_t) == sizeof(void*), "size_t is not big enough to hold pointer address");
   if (((size_t)newptr & (OPS_ALIGNMENT - 1)) != 0) {
-    // void *newptr2=NULL;
-    // if( posix_memalign((void**)&(newptr2), OPS_ALIGNMENT, size) ) {
-    //     OPSException ex(OPS_INTERNAL_ERROR);
-    //     ex << "Error, posix_memalign() returned an error.";
-    //     throw ex;
-    // }
-    void *newptr2 = _mm_malloc(size, OPS_ALIGNMENT);
+    void *newptr2=NULL;
+    if( posix_memalign((void**)&(newptr2), OPS_ALIGNMENT, size) ) {
+        OPSException ex(OPS_INTERNAL_ERROR);
+        ex << "Error, posix_memalign() returned an error.";
+        throw ex;
+    }
+    //void *newptr2 = _mm_malloc(size, OPS_ALIGNMENT);
     memcpy(newptr2, newptr, size);
     ops_free(newptr);
     return newptr2;
@@ -1984,7 +1984,7 @@ void ops_free(void *ptr) {
 #if defined (_WIN32) || defined(WIN32)
   _aligned_free(ptr);
 #else
-  _mm_free(ptr);
+  free(ptr);
 #endif
 }
 

--- a/ops/c/src/cuda/ops_cuda_common.cu
+++ b/ops/c/src/cuda/ops_cuda_common.cu
@@ -153,6 +153,9 @@ void cutilDeviceInit(OPS_instance *instance, const int argc, const char * const 
     cutilSafeCall(instance->ostream(), cudaGetDeviceProperties(&deviceProp, deviceId));
     if (instance->OPS_diags>=1) instance->ostream() << "\n Using CUDA device: " <<
       deviceId << " " << deviceProp.name <<"\n";
+
+    // Initialize GPU power measurement
+    _ops_reset_gpu_power_counters(instance);
   } else {
     throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: no available CUDA devices");
   }
@@ -212,6 +215,7 @@ void ops_fill_random_uniform(ops_dat dat) {
     iter_range[2*n+1] = dat->size[n];
   }
   ops_set_halo_dirtybit3(&arg, iter_range);
+  delete[] iter_range;
 }
 
 void ops_fill_random_normal(ops_dat dat) {
@@ -255,4 +259,114 @@ void ops_randomgen_exit() {
     curand_initialised = 0;
     curandSafeCall(instance->ostream(), curandDestroyGenerator(ops_rand_gen));
   }
+}
+
+/*
+ * GPU Power Measurement Functions using NVML
+ */
+
+#if OPS_ENABLE_NVML
+#include <nvml.h>
+
+// NVML device handle for current GPU
+static nvmlDevice_t nvml_device = NULL;
+static bool nvml_initialized = false;
+
+void __nvmlSafeCall(nvmlReturn_t result, const char *file, int line) {
+    if (result != NVML_SUCCESS) {
+        fprintf(stderr, "NVML error at %s:%d - %s\n", file, line, nvmlErrorString(result));
+        // Don't throw exception, just disable GPU power measurement
+        nvml_initialized = false;
+    }
+}
+
+#define nvmlSafeCall(call) __nvmlSafeCall(call, __FILE__, __LINE__)
+
+#endif // OPS_ENABLE_NVML
+
+void _ops_init_gpu_power_measurement(OPS_instance *instance) {
+#if OPS_ENABLE_NVML
+    nvmlReturn_t result;
+    
+    // Initialize NVML
+    result = nvmlInit();
+    if (result != NVML_SUCCESS) {
+        if (instance->OPS_diags > 4) {
+            instance->ostream() << "Warning: Failed to initialize NVML for GPU power measurement: " 
+                               << nvmlErrorString(result) << std::endl;
+        }
+        nvml_initialized = false;
+        return;
+    }
+    
+    // Get current CUDA device
+    int deviceId = -1;
+    cudaError_t cuda_result = cudaGetDevice(&deviceId);
+    if (cuda_result != cudaSuccess) {
+        if (instance->OPS_diags > 4) {
+            instance->ostream() << "Warning: Failed to get current CUDA device for power measurement" << std::endl;
+        }
+        nvml_initialized = false;
+        return;
+    }
+    
+    // Get NVML device handle
+    result = nvmlDeviceGetHandleByIndex(deviceId, &nvml_device);
+    if (result != NVML_SUCCESS) {
+        if (instance->OPS_diags > 4) {
+            instance->ostream() << "Warning: Failed to get NVML device handle: " 
+                               << nvmlErrorString(result) << std::endl;
+        }
+        nvml_initialized = false;
+        return;
+    }
+    
+    nvml_initialized = true;
+    if (instance->OPS_diags > 4) {
+        instance->ostream() << "GPU power measurement initialized using NVML" << std::endl;
+    }
+#else
+    (void)instance; // Suppress unused parameter warning
+    nvml_initialized = false;
+    if (instance->OPS_diags > 4) {
+        instance->ostream() << "GPU power measurement not available (NVML disabled)" << std::endl;
+    }
+#endif
+}
+
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
+    (void)instance; // Suppress unused parameter warning
+    
+    *power_watts = 0; // Default to 0 if measurement fails
+    
+#if OPS_ENABLE_NVML
+    if (!nvml_initialized || nvml_device == NULL) {
+        return;
+    }
+    
+    nvmlReturn_t result = nvmlDeviceGetPowerUsage(nvml_device, power_watts);
+    if (result != NVML_SUCCESS) {
+        if (instance->OPS_diags > 3) {
+            instance->ostream() << "Warning: Failed to get GPU power usage: " 
+                               << nvmlErrorString(result) << std::endl;
+        }
+        *power_watts = 0;
+        return;
+    }
+    
+    // Convert from milliwatts to watts
+    *power_watts = *power_watts / 1000;
+#endif
+}
+
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    
+#if OPS_ENABLE_NVML
+    if (nvml_initialized) {
+        nvmlShutdown();
+        nvml_initialized = false;
+        nvml_device = NULL;
+    }
+#endif
 }

--- a/ops/c/src/cuda/ops_cuda_common.cu
+++ b/ops/c/src/cuda/ops_cuda_common.cu
@@ -134,13 +134,33 @@ void cutilDeviceInit(OPS_instance *instance, const int argc, const char * const 
   float *test = 0;
   int my_id = ops_get_proc();
   instance->OPS_hybrid_gpu = 0;
-  for (int i = 0; i < deviceCount; i++) {
-    cudaError_t err = cudaSetDevice((i+my_id)%deviceCount);
+  
+  if (instance->OPS_device_id >= 0) {
+    // User specified a device ID
+    if (instance->OPS_device_id >= deviceCount) {
+      throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: specified CUDA device ID exceeds available device count");
+    }
+    cudaError_t err = cudaSetDevice(instance->OPS_device_id);
     if (err == cudaSuccess) {
       cudaError_t err2 = cudaMalloc((void **)&test, sizeof(float));
       if (err2 == cudaSuccess) {
         instance->OPS_hybrid_gpu = 1;
-        break;
+      } else {
+        throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: specified CUDA device is not accessible");
+      }
+    } else {
+      throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: failed to set specified CUDA device");
+    }
+  } else {
+    // Auto-select device
+    for (int i = 0; i < deviceCount; i++) {
+      cudaError_t err = cudaSetDevice((i+my_id)%deviceCount);
+      if (err == cudaSuccess) {
+        cudaError_t err2 = cudaMalloc((void **)&test, sizeof(float));
+        if (err2 == cudaSuccess) {
+          instance->OPS_hybrid_gpu = 1;
+          break;
+        }
       }
     }
   }

--- a/ops/c/src/hip/ops_hip_common.cpp
+++ b/ops/c/src/hip/ops_hip_common.cpp
@@ -350,7 +350,7 @@ void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
     rsmi_status_t result;
     
     // Use newer API for ROCm 6.0+ or fall back to older API
-#if defined(RSMI_VERSION_MAJOR) && (RSMI_VERSION_MAJOR >= 6)
+#if defined(HIP_VERSION_MAJOR) && (HIP_VERSION_MAJOR >= 6)
     // ROCm 6.0+ - use rsmi_dev_power_get
     RSMI_POWER_TYPE power_type;
     result = rsmi_dev_power_get(rocm_device_id, &power_microwatts, &power_type);

--- a/ops/c/src/hip/ops_hip_common.cpp
+++ b/ops/c/src/hip/ops_hip_common.cpp
@@ -132,13 +132,33 @@ void cutilDeviceInit(OPS_instance *instance, const int argc, const char * const 
   float *test = 0;
   int my_id = ops_get_proc();
   instance->OPS_hybrid_gpu = 0;
-  for (int i = 0; i < deviceCount; i++) {
-    hipError_t err = hipSetDevice((i+my_id)%deviceCount);
+  
+  if (instance->OPS_device_id >= 0) {
+    // User specified a device ID
+    if (instance->OPS_device_id >= deviceCount) {
+      throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: specified HIP device ID exceeds available device count");
+    }
+    hipError_t err = hipSetDevice(instance->OPS_device_id);
     if (err == hipSuccess) {
       hipError_t err2 = hipMalloc((void **)&test, sizeof(float));
       if (err2 == hipSuccess) {
         instance->OPS_hybrid_gpu = 1;
-        break;
+      } else {
+        throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: specified HIP device is not accessible");
+      }
+    } else {
+      throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: failed to set specified HIP device");
+    }
+  } else {
+    // Auto-select device
+    for (int i = 0; i < deviceCount; i++) {
+      hipError_t err = hipSetDevice((i+my_id)%deviceCount);
+      if (err == hipSuccess) {
+        hipError_t err2 = hipMalloc((void **)&test, sizeof(float));
+        if (err2 == hipSuccess) {
+          instance->OPS_hybrid_gpu = 1;
+          break;
+        }
       }
     }
   }

--- a/ops/c/src/hip/ops_hip_common.cpp
+++ b/ops/c/src/hip/ops_hip_common.cpp
@@ -151,6 +151,9 @@ void cutilDeviceInit(OPS_instance *instance, const int argc, const char * const 
     hipSafeCall(instance->ostream(), hipGetDeviceProperties(&deviceProp, deviceId));
     if (instance->OPS_diags>=1) instance->ostream() << "\n Using HIP device: " <<
       deviceId << " " << deviceProp.name <<"\n";
+
+    // Initialize GPU power measurement
+    _ops_reset_gpu_power_counters(instance);
   } else {
     throw OPSException(OPS_RUNTIME_CONFIGURATION_ERROR, "Error: no available HIP devices");
   }
@@ -255,4 +258,120 @@ void ops_randomgen_exit() {
     hiprand_initialised = 0;
     hiprandSafeCall(instance->ostream(), hiprandDestroyGenerator(ops_rand_gen));
   }
+}
+
+/*
+ * GPU Power Measurement Functions using ROCm SMI
+ */
+
+#if OPS_ENABLE_ROCM_SMI
+#include <rocm_smi/rocm_smi.h>
+
+// ROCm SMI device handle for current GPU
+static uint32_t rocm_device_id = 0;
+static bool rocm_smi_initialized = false;
+static uint32_t rocm_num_devices = 0;
+
+void __rocmSmiSafeCall(rsmi_status_t result, const char *file, int line) {
+    if (result != RSMI_STATUS_SUCCESS) {
+        fprintf(stderr, "ROCm SMI error at %s:%d - error code %d\n", file, line, result);
+        // Don't throw exception, just disable GPU power measurement
+        rocm_smi_initialized = false;
+    }
+}
+
+#define rocmSmiSafeCall(call) __rocmSmiSafeCall(call, __FILE__, __LINE__)
+
+#endif // OPS_ENABLE_ROCM_SMI
+
+void _ops_init_gpu_power_measurement(OPS_instance *instance) {
+#if OPS_ENABLE_ROCM_SMI
+    rsmi_status_t result;
+    
+    // Initialize ROCm SMI
+    result = rsmi_init(0);
+    if (result != RSMI_STATUS_SUCCESS) {
+        if (instance->OPS_diags > 4) {
+            instance->ostream() << "Warning: Failed to initialize ROCm SMI for GPU power measurement: error " 
+                               << result << std::endl;
+        }
+        rocm_smi_initialized = false;
+        return;
+    }
+    
+    // Get number of monitoring devices
+    result = rsmi_num_monitor_devices(&rocm_num_devices);
+    if (result != RSMI_STATUS_SUCCESS || rocm_num_devices == 0) {
+        if (instance->OPS_diags > 4) {
+            instance->ostream() << "Warning: No ROCm SMI monitoring devices found" << std::endl;
+        }
+        rocm_smi_initialized = false;
+        return;
+    }
+    
+    // Get current HIP device (assumes it matches ROCm SMI device index)
+    int deviceId = -1;
+    hipError_t hip_result = hipGetDevice(&deviceId);
+    if (hip_result != hipSuccess || deviceId < 0 || (uint32_t)deviceId >= rocm_num_devices) {
+        if (instance->OPS_diags > 4) {
+            instance->ostream() << "Warning: Failed to get current HIP device for power measurement" << std::endl;
+        }
+        rocm_smi_initialized = false;
+        return;
+    }
+    
+    rocm_device_id = (uint32_t)deviceId;
+    rocm_smi_initialized = true;
+    
+    if (instance->OPS_diags > 4) {
+        instance->ostream() << "GPU power measurement initialized using ROCm SMI for device " 
+                           << rocm_device_id << std::endl;
+    }
+#else
+    (void)instance; // Suppress unused parameter warning
+    rocm_smi_initialized = false;
+    if (instance->OPS_diags > 4) {
+        instance->ostream() << "GPU power measurement not available (ROCm SMI disabled)" << std::endl;
+    }
+#endif
+}
+
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
+    (void)instance; // Suppress unused parameter warning
+    
+    *power_watts = 0; // Default to 0 if measurement fails
+    
+#if OPS_ENABLE_ROCM_SMI
+    if (!rocm_smi_initialized) {
+        return;
+    }
+    
+    uint64_t power_microwatts = 0;
+    RSMI_POWER_TYPE power_type;
+    rsmi_status_t result = rsmi_dev_power_get(rocm_device_id, &power_microwatts, &power_type);
+    if (result != RSMI_STATUS_SUCCESS || power_type == RSMI_INVALID_POWER) {
+        if (instance->OPS_diags > 3) {
+            instance->ostream() << "Warning: Failed to get GPU power usage from ROCm SMI: error " 
+                               << result << std::endl;
+        }
+        *power_watts = 0;
+        return;
+    }
+    
+    // Convert from microwatts to watts
+    *power_watts = (unsigned int)(power_microwatts / 1000000);
+#endif
+}
+
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    
+#if OPS_ENABLE_ROCM_SMI
+    if (rocm_smi_initialized) {
+        rsmi_shut_down();
+        rocm_smi_initialized = false;
+        rocm_device_id = 0;
+        rocm_num_devices = 0;
+    }
+#endif
 }

--- a/ops/c/src/hip/ops_hip_common.cpp
+++ b/ops/c/src/hip/ops_hip_common.cpp
@@ -347,16 +347,33 @@ void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
     }
     
     uint64_t power_microwatts = 0;
+    rsmi_status_t result;
+    
+    // Use newer API for ROCm 6.0+ or fall back to older API
+#if defined(RSMI_VERSION_MAJOR) && (RSMI_VERSION_MAJOR >= 6)
+    // ROCm 6.0+ - use rsmi_dev_power_get
     RSMI_POWER_TYPE power_type;
-    rsmi_status_t result = rsmi_dev_power_get(rocm_device_id, &power_microwatts, &power_type);
+    result = rsmi_dev_power_get(rocm_device_id, &power_microwatts, &power_type);
     if (result != RSMI_STATUS_SUCCESS || power_type == RSMI_INVALID_POWER) {
         if (instance->OPS_diags > 3) {
-            instance->ostream() << "Warning: Failed to get GPU power usage from ROCm SMI: error " 
+            instance->ostream() << "Warning: Failed to get GPU power usage from ROCm SMI (6+ API): error " 
                                << result << std::endl;
         }
         *power_watts = 0;
         return;
     }
+#else
+    // ROCm 5.x and earlier - use rsmi_dev_power_ave_get
+    result = rsmi_dev_power_ave_get(rocm_device_id, 0, &power_microwatts);
+    if (result != RSMI_STATUS_SUCCESS) {
+        if (instance->OPS_diags > 3) {
+            instance->ostream() << "Warning: Failed to get GPU power usage from ROCm SMI (5.x API): error " 
+                               << result << std::endl;
+        }
+        *power_watts = 0;
+        return;
+    }
+#endif
     
     // Convert from microwatts to watts
     *power_watts = (unsigned int)(power_microwatts / 1000000);

--- a/ops/c/src/mpi/ops_mpi_rt_support.cpp
+++ b/ops/c/src/mpi/ops_mpi_rt_support.cpp
@@ -680,7 +680,7 @@ void ops_exchange_halo_unpacker_given(ops_dat dat, int *depths, int dim,
 }
 
 void ops_halo_exchanges(ops_arg* args, int nargs, int *range_in) {
-  // double c1,c2,t1,t2;
+  double c,t1,t2;
   // printf("*************** range[i] %d %d %d %d\n",range[0],range[1],range[2],
   // range[3]);
   int send_recv_offsets[4]; //{send_1, recv_1, send_2, recv_2}, for the two
@@ -793,6 +793,12 @@ void ops_halo_exchanges(ops_arg* args, int nargs, int *range_in) {
     MPI_Status status[4];
     MPI_Waitall(2, &request[2], &status[2]);
 
+    OPS_instance::getOPSInstance()->ops_message_count +=
+      (send_recv_offsets[0] > 0) + (send_recv_offsets[2] > 0);
+    OPS_instance::getOPSInstance()->ops_message_size +=
+      send_recv_offsets[0] + send_recv_offsets[2];
+    
+
     //  ops_timers_core(&c1,&t1);
     //  ops_sendrecv_time += t1-t2;
 
@@ -891,6 +897,11 @@ void ops_halo_exchanges_datlist(ops_dat *dats, int ndats, int *depths) {
 
     MPI_Status status[4];
     MPI_Waitall(2, &request[2], &status[2]);
+
+    OPS_instance::getOPSInstance()->ops_message_count +=
+      (send_recv_offsets[0] > 0) + (send_recv_offsets[2] > 0);
+    OPS_instance::getOPSInstance()->ops_message_size +=
+      send_recv_offsets[0] + send_recv_offsets[2];
 
     //  ops_timers_core(&c1,&t1);
     //  printf("1 %g %d\n", t1-t2, send_recv_offsets[0] + send_recv_offsets[2]);
@@ -1022,6 +1033,9 @@ ops_reduce_gen(complexf, MPI_C_FLOAT_COMPLEX, complexf(0.0f,0.0f))
 
 void ops_execute_reduction(ops_reduction handle) {
 
+  double c, t1, t2;
+  if (OPS_instance::getOPSInstance()->OPS_diags > 1)
+    ops_timers_core(&c, &t1);
   if (strcmp(handle->type, "int") == 0 ||
       strcmp(handle->type, "int(4)") == 0 ||
       strcmp(handle->type, "integer") == 0 ||
@@ -1090,7 +1104,10 @@ void ops_execute_reduction(ops_reduction handle) {
     ex << "Error: Unknown data type for ops_reduction";
     throw ex;
   }
-
+  if (OPS_instance::getOPSInstance()->OPS_diags > 1) {
+    ops_timers_core(&c, &t2);
+    OPS_instance::getOPSInstance()->ops_reduction_time += (t2-t1);
+  }
 }
 
 void ops_set_halo_dirtybit(ops_arg *arg) {

--- a/ops/c/src/ompoffload/ops_ompoffload_common_omp4.cpp
+++ b/ops/c/src/ompoffload/ops_ompoffload_common_omp4.cpp
@@ -133,3 +133,23 @@ void ops_fill_random_normal(ops_dat dat) {
 
 void ops_randomgen_exit() {
 }
+
+/*
+ * GPU Power Measurement Functions (OpenMP Offload OMP4 backends)
+ * These return zero values since OpenMP offload power measurement is not implemented
+ */
+
+void _ops_init_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for OpenMP offload backends - power measurement not implemented
+}
+
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
+    (void)instance; // Suppress unused parameter warning
+    *power_watts = 0; // Always return 0 for OpenMP offload backends
+}
+
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for OpenMP offload backends
+}

--- a/ops/c/src/ompoffload/ops_ompoffload_common_omp5.cpp
+++ b/ops/c/src/ompoffload/ops_ompoffload_common_omp5.cpp
@@ -151,3 +151,23 @@ void ops_fill_random_normal(ops_dat dat) {
 
 void ops_randomgen_exit() {
 }
+
+/*
+ * GPU Power Measurement Functions (OpenMP Offload OMP5 backends)
+ * These return zero values since OpenMP offload power measurement is not implemented
+ */
+
+void _ops_init_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for OpenMP offload backends - power measurement not implemented
+}
+
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
+    (void)instance; // Suppress unused parameter warning
+    *power_watts = 0; // Always return 0 for OpenMP offload backends
+}
+
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for OpenMP offload backends
+}

--- a/ops/c/src/opencl/ops_opencl_common.cpp
+++ b/ops/c/src/opencl/ops_opencl_common.cpp
@@ -407,3 +407,23 @@ void ops_fill_random_normal(ops_dat dat) {
 
 void ops_randomgen_exit() {
 }
+
+/*
+ * GPU Power Measurement Functions (OpenCL backends)
+ * These return zero values since OpenCL power measurement is not implemented
+ */
+
+void _ops_init_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for OpenCL backends - power measurement not implemented
+}
+
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
+    (void)instance; // Suppress unused parameter warning
+    *power_watts = 0; // Always return 0 for OpenCL backends
+}
+
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for OpenCL backends
+}

--- a/ops/c/src/sequential/ops_host_common.cpp
+++ b/ops/c/src/sequential/ops_host_common.cpp
@@ -122,3 +122,23 @@ void ops_fill_random_normal(ops_dat dat) {
 
 void ops_randomgen_exit() {
 }
+
+/*
+ * GPU Power Measurement Functions (Sequential/Single-node backends)
+ * These return zero values since there's no GPU in sequential execution
+ */
+
+void _ops_init_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for sequential backends - no GPU to measure
+}
+
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
+    (void)instance; // Suppress unused parameter warning
+    *power_watts = 0; // Always return 0 for sequential backends
+}
+
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for sequential backends
+}

--- a/ops/c/src/sycl/ops_sycl_common.cpp
+++ b/ops/c/src/sycl/ops_sycl_common.cpp
@@ -168,3 +168,23 @@ void ops_fill_random_normal(ops_dat dat) {
 
 void ops_randomgen_exit() {
 }
+
+/*
+ * GPU Power Measurement Functions (SYCL backends)
+ * These return zero values since SYCL power measurement is not implemented
+ */
+
+void _ops_init_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for SYCL backends - power measurement not implemented
+}
+
+void _ops_get_gpu_power(OPS_instance *instance, unsigned int *power_watts) {
+    (void)instance; // Suppress unused parameter warning
+    *power_watts = 0; // Always return 0 for SYCL backends
+}
+
+void _ops_finalize_gpu_power_measurement(OPS_instance *instance) {
+    (void)instance; // Suppress unused parameter warning
+    // Do nothing for SYCL backends
+}

--- a/ops_translator_legacy/c/ops_gen_mpi_lazy.py
+++ b/ops_translator_legacy/c/ops_gen_mpi_lazy.py
@@ -458,27 +458,31 @@ def ops_gen_mpi_lazy(master, consts, kernels, soa_set, offload=0):
 
         if NDIM > 1:
             if offload == 0:
-                temp_depth = config.depth
-                config.depth = 0
-                code("#ifdef __INTEL_COMPILER")
-                config.depth = temp_depth
-                code("#pragma loop_count(10000)")
-                code("#pragma omp simd" + line)  # +' aligned('+clean_type(line3[:-1])+')')
-                config.depth = 0
-                code("#elif defined(__clang__)")
-                config.depth = temp_depth
-                code("#pragma clang loop vectorize(disable)")
-                config.depth = 0
-                code("#elif defined(__GNUC__)")
-                config.depth = temp_depth
-                code("#pragma GCC ivdep")
-                config.depth = 0
-                code("#else")
-                config.depth = temp_depth
-                code("#pragma simd")
-                config.depth = 0
-                code("#endif")
-                config.depth = temp_depth
+#                temp_depth = config.depth
+#                config.depth = 0
+#                code("#ifdef __INTEL_COMPILER")
+#                config.depth = temp_depth
+#                code("#pragma loop_count(10000)")
+                simdlen = ''
+                for arg in range(0, nargs):
+                    if typs[arg] == "half":
+                        simdlen = ' simdlen(32)'
+                code("#pragma omp simd" +simdlen + line)  # +' aligned('+clean_type(line3[:-1])+')')
+#                config.depth = 0
+#                code("#elif defined(__clang__)")
+#                config.depth = temp_depth
+#                code("#pragma clang loop vectorize(assume_safety)")
+#                config.depth = 0
+#                code("#elif defined(__GNUC__)")
+#                config.depth = temp_depth
+#                code("#pragma GCC ivdep")
+#                config.depth = 0
+#                code("#else")
+#                config.depth = temp_depth
+#                code("#pragma simd")
+#                config.depth = 0
+#                code("#endif")
+#                config.depth = temp_depth
         if offload == 1:
             FOR("n_x", "start0", "end0")
         else:


### PR DESCRIPTION
This initializes energy counters when the application starts, and measures CPU energy consumption (including RAM). Counters can be specified with the REPL_PATH environment variable, but are by default in the "default" path for 2 socket systems. Reports consumption at the end of ops_timing_output as Joules.