### PR TITLE
Blackwell support, removing flags  for older unsupported archs

### DIFF
--- a/makefiles/Makefile.cuda
+++ b/makefiles/Makefile.cuda
@@ -19,7 +19,7 @@ else
 endif
 
 ifndef NV_ARCH
-NVCCFLAGS+=-gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_75,code=compute_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_80,code=compute_80
+NVCCFLAGS+=-gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_90,code=sm_90
 endif
 
 ifeq ($(NV_ARCH),Kepler)
@@ -39,6 +39,10 @@ NVCCFLAGS+=-gencode arch=compute_80,code=sm_80
 else
 ifeq ($(NV_ARCH),Hopper)
 NVCCFLAGS+=-gencode arch=compute_90,code=sm_90
+else
+ifeq ($(NV_ARCH),Blackwell)
+NVCCFLAGS+=-gencode arch=compute_100,code=sm_100
+endif
 endif
 endif
 endif


### PR DESCRIPTION
To fix #261 - didn't add blackwell to the default list due to lack of support in older compilers